### PR TITLE
feat(instance): Add --instance option to arguments and config

### DIFF
--- a/.kci-dev.toml.example
+++ b/.kci-dev.toml.example
@@ -1,3 +1,13 @@
-[connection]
+default_instance="local"
+
+[local]
 host="https://127.0.0.1"
+token="example"
+
+[staging]
+host="https://staging.kernelci.org:9100/"
+token="example"
+
+[production]
+host="https://kernelci-pipeline.westus3.cloudapp.azure.com/"
 token="example"

--- a/kci-dev/kci-dev.py
+++ b/kci-dev/kci-dev.py
@@ -11,9 +11,20 @@ from subcommands import commit, patch
 )
 @click.version_option("0.0.1", prog_name="kci-dev")
 @click.option("--settings", default=".kci-dev.toml", help="path of toml setting file")
+@click.option("--instance", help="API instance to use", required=False)
 @click.pass_context
-def cli(ctx, settings):
+def cli(ctx, settings, instance):
     ctx.obj = {"CFG": load_toml(settings)}
+    if instance:
+        ctx.obj["INSTANCE"] = instance
+    else:
+        ctx.obj["INSTANCE"] = ctx.obj["CFG"].get("default_instance")
+    if not ctx.obj["INSTANCE"]:
+        click.secho("No instance defined in settings or as argument", fg="red")
+        raise click.Abort()
+    if ctx.obj["INSTANCE"] not in ctx.obj["CFG"]:
+        click.secho(f"Instance {ctx.obj['INSTANCE']} not found in {settings}", fg="red")
+        raise click.Abort()
     pass
 
 

--- a/kci-dev/subcommands/commit.py
+++ b/kci-dev/subcommands/commit.py
@@ -62,9 +62,10 @@ def send_build(url, patch, branch, treeurl, token):
 @click.pass_context
 def commit(ctx, repository, branch, private, path):
     config = ctx.obj.get("CFG")
-    url = api_connection(config["connection"]["host"])
+    instance = ctx.obj.get("INSTANCE")
+    url = api_connection(config[instance]["host"])
     diff = find_diff(path, branch, repository)
-    send_build(url, diff, branch, repository, config["connection"]["token"])
+    send_build(url, diff, branch, repository, config[instance]["token"])
 
 
 if __name__ == "__main__":

--- a/kci-dev/subcommands/patch.py
+++ b/kci-dev/subcommands/patch.py
@@ -48,9 +48,10 @@ def send_build(url, patch, branch, treeurl, token):
 @click.pass_context
 def patch(ctx, repository, branch, private, patch):
     config = ctx.obj.get("CFG")
-    url = api_connection(config["connection"]["host"])
+    instance = ctx.obj.get("INSTANCE")
+    url = api_connection(config[instance]["host"])
     patch = open(patch, "rb")
-    send_build(url, patch, branch, repository, config["connection"]["token"])
+    send_build(url, patch, branch, repository, config[instance]["token"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Add option to quickly change instance. Might be handy to change instance during testing some feature.

For example:
./kci-dev --instance=local commit ...options...
(Works fine, time to test on staging)
./kci-dev --instance=staging commit ...options...
It might need minor changes for existing config files, to specify default_instance option, but otherwise cli options remain backward compatible.