### PR TITLE
fix(checkout.py): Due pydantic update change field name

### DIFF
--- a/kci-dev/subcommands/checkout.py
+++ b/kci-dev/subcommands/checkout.py
@@ -150,8 +150,9 @@ def watch_jobs(baseurl, token, treeid, jobfilter, test):
                             fg="red",
                         )
                         sys.exit(2)
+                nodeid = node.get("id")
                 click.secho(
-                    f"Node {node['_id']} job {node['name']} State {node['state']} Result {node['result']}",
+                    f"Node {nodeid} job {node['name']} State {node['state']} Result {node['result']}",
                     fg=color,
                 )
         if len(joblist) == 0 and inprogress == 0:


### PR DESCRIPTION
As we upgraded pydantic, there is some schema changes and field _id is translated to id.
Update code, and avoid exception if we hit old endpoint.