### PR TITLE
Add global config

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -23,7 +23,13 @@ poetry run kci-dev
 
 ## Configuration
 
-kci-dev uses a configuration file .kci-dev.toml in the program directory.
+kci-dev searches for and loads a configuration file in the following order of priority:
+1) The global configuration file located at /etc/kci-dev.toml.
+2) The user-specific configuration file at ~/.config/kci-dev/kci-dev.toml
+3) A site-specific configuration file, which is .kci-dev.toml by default, but can be overridden with the --settings option. 
+
+Priority: The configuration files are loaded in the order listed above, with each subsequent file overriding the settings from the previous one. If a user-specific file is present, it will override the global configuration. The site-specific file, whether default or specified by --settings, takes precedence over both the global and user-specific configuration files.
+
 ```toml
 default_instance="local"
 

--- a/kcidev/libs/common.py
+++ b/kcidev/libs/common.py
@@ -1,10 +1,20 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
+import os
+
 import toml
 
 
 def load_toml(settings):
+    if not settings:
+        if os.path.exists(".kci-dev.toml"):
+            settings = ".kci-dev.toml"
+        else:
+            homedir = os.path.expanduser("~")
+            settings = os.path.join(homedir, ".config", "kci-dev.toml")
+    if not os.path.exists(settings):
+        raise FileNotFoundError(f"Settings file {settings} not found")
     with open(settings) as fp:
         config = toml.load(fp)
     return config

--- a/kcidev/main.py
+++ b/kcidev/main.py
@@ -11,7 +11,7 @@ from kcidev.subcommands import checkout, commit, patch, results, testretry
     help="Stand alone tool for Linux Kernel developers and maintainers that can test local Linux Kernel changes on a enabled KernelCI server"
 )
 @click.version_option("0.1.0", prog_name="kci-dev")
-@click.option("--settings", default=".kci-dev.toml", help="path of toml setting file")
+@click.option("--settings", default=None, help="path of toml setting file")
 @click.option("--instance", help="API instance to use", required=False)
 @click.pass_context
 def cli(ctx, settings, instance):


### PR DESCRIPTION
Implement support for a global configuration file to enable kci-dev functionality across any source directory location, but keep support of local configuration file. This enhancement will allow for more flexible project setup and improved workflow portability.