### PR TITLE
github/workflows/pypi-test: Publish new release on pypi

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,0 +1,14 @@
+name: Publish package to PyPI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  pypi_publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: JRubics/poetry-publish@v2.0
+        with:
+          pypi_token: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/pypi-test.yml
+++ b/.github/workflows/pypi-test.yml
@@ -1,0 +1,21 @@
+name: Publish package to test.pypi
+
+on:
+  push:
+    tags:
+      - "v*.*.*.dev*"
+      - "v*.*.*.post*"
+      - "v*.*.*.rc*"
+      - "v*.*.*.a*"
+      - "v*.*.*.b*"
+
+jobs:
+  pypi_test_publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: JRubics/poetry-publish@v2.0
+        with:
+          pypi_token: ${{ secrets.TEST_PYPI_TOKEN }}
+          repository_name: "testpypi"
+          repository_url: "https://test.pypi.org/legacy/"


### PR DESCRIPTION
This pull request will publish kci-dev to PyPI automatically when a new release is published
Will also publish to test.pypi when the following tags are matched
```
      - "v*.*.*.dev*"
      - "v*.*.*.post*"
      - "v*.*.*.rc*"
      - "v*.*.*.a*"
      - "v*.*.*.b*"
```
