### PR TITLE
config: show a nice error message if not config is available

### DIFF
--- a/kcidev/libs/common.py
+++ b/kcidev/libs/common.py
@@ -3,6 +3,7 @@
 
 import os
 
+import click
 import toml
 
 
@@ -26,6 +27,10 @@ def load_toml(settings):
             config = toml.load(f)
 
     if not config:
-        raise FileNotFoundError("No configuration file found")
+        click.secho(
+            f"No `{fname}` configuration file found at `{global_path}`, `{user_path}` or `{settings}`",
+            fg="red",
+        )
+        raise click.Abort()
 
     return config


### PR DESCRIPTION
Users will be clueless for a moment if we give them a dump, instead of a clear message.