### PR TITLE
Experimental command to fetch results from the Dashboard API

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 > *cmdline tool for interact with KernelCI*
 
-kci-dev is a cmdline tool for interact with a enabled KernelCI server
+Stand alone tool for Linux Kernel developers and maintainers to interact with KernelCI services.
 
 ## Quickstart
 

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -4,25 +4,45 @@ date = 2024-01-14T07:07:07+01:00
 description = 'Tool for interact programmatically with KernelCI instances.'
 +++
 
-kci-dev is a cmdline tool for interact with a enabled KernelCI server.  
-Purpose of this tool to provide a easy way to use features of KernelCI Pipeline instance.  
+Stand alone tool for Linux Kernel developers and maintainers to interact with KernelCI.
+
+Purpose of this tool to provide an easy-to-use command line tool for developers and maintainers request test from KernelCI, view results, download logs, integrate with scripts, etc.
 
 ## Installation
 
-### Using PyPI and virtualenv
+You may want to use python virtual environment.
+If you are not familiar with it, check [this](https://docs.python.org/3/library/venv.html).
+
+To quickly setup it:
+
 ```sh
 virtualenv .venv
 source .venv/bin/activate
+```
+
+### Using package from PyPI
+
+Simply install it using `pip`:
+
+```sh
 pip install kci-dev
 ```
 
-### Using poetry and virtualenv
+### Development snapshot through poetry
+
+Clone the `kci-dev` repo you want, select the desired branch and run:
+
 ```sh
 virtualenv .venv
 source .venv/bin/activate
 pip install poetry
 poetry install
-poetry run kci-dev
+```
+
+Then, to execute kci-dev:
+
+```sh
+poetry run kci-dev <options>
 ```
 
 ## Configuration

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -102,6 +102,12 @@ Example:
 kci-dev --settings /path/to/.kci-dev.toml
 ```
 
+### General Commands
+
+#### results
+
+Pull results from the Dashboard. See detailed [documentation](results).
+
 ### Maestro Commands
 
 #### checkout

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -27,6 +27,8 @@ poetry run kci-dev
 
 ## Configuration
 
+> Configuration is only necessary if you are using any of the Maestro Commands listed in the Maestro section.
+
 kci-dev searches for and loads a configuration file in the following order of priority:
 1) The global configuration file located at /etc/kci-dev.toml.
 2) The user-specific configuration file at ~/.config/kci-dev/kci-dev.toml
@@ -61,9 +63,9 @@ pipeline is the URL of the KernelCI Pipeline API endpoint, api is the URL of the
 If you are using KernelCI Pipeline instance, you can get the token from the project maintainers.  
 If it is a local instance, you can generate your token using [kernelci-pipeline/tools/jwt_generator.py](https://github.com/kernelci/kernelci-pipeline/blob/main/tools/jwt_generator.py) script.  
 
-## Options
+### Configuration options
 
-### instance
+#### --instance
 You can provide the instance name to use for the command.
 
 Example:
@@ -71,7 +73,7 @@ Example:
 kci-dev --instance staging
 ```
 
-### settings
+#### --settings
 
 You can provide the configuration file path to use for the command.
 
@@ -80,17 +82,17 @@ Example:
 kci-dev --settings /path/to/.kci-dev.toml
 ```
 
-## Commands
+### Maestro Commands
 
-### checkout
+#### checkout
 
 - [checkout](checkout)
 
-### testretry
+#### testretry
 
 - [testretry](testretry)
 
-### results
+#### maestro-results
 
-- [results](results)
+- [maestro-results](maestro-results)
 

--- a/docs/maestro-results.md
+++ b/docs/maestro-results.md
@@ -1,21 +1,23 @@
 +++
-title = 'results'
+title = 'maestro-results'
 date = 2024-01-14T07:07:07+01:00
-description = 'Command for show test results.'
+description = 'Command for show Maestro test results.'
 +++
 
-This command will show the test result by node id.
+This command is Maestro-specific and will show the test result by node id.
+
+Do not use it, unless you are requesting test on Maestro through `kci-dev`.
 
 Example:
 ```sh
-kci-dev results --nodeid <str: testnodeid>
+kci-dev maestro-results --nodeid <str: testnodeid>
 ```
 
 This command will show the results of tests by page nodes limit and page offset.
 
 Example:
 ```sh
-kci-dev results --nodes --limit <int: page nodes limit> --offset <int: page nodes offset>
+kci-dev maestro-results --nodes --limit <int: page nodes limit> --offset <int: page nodes offset>
 ```
 
 Result sample:

--- a/docs/results.md
+++ b/docs/results.md
@@ -1,0 +1,66 @@
++++
+title = 'results'
+date = 2024-12-10T07:07:07+01:00
+description = 'Fetch results from the KernelCI ecosystem.'
++++
+
+`kci-dev` pulls from our Dashboard API. As of now, it is an EXPERIMENTAL tooling under development with close collaboration from Linux kernel maintainers.
+
+> KNOWN ISSUE: The Dashboard endpoint we are using returns a file of a few megabytes in size, so download may take
+a few seconds, slowing down your usage of `kci-dev results`. We are working on [it](https://github.com/kernelci/dashboard/issues/661).
+
+## Base parameters
+
+### --origin
+
+Set the KCIDB origin desired. 'maestro' is the default.
+
+### --giturl
+
+The url of the tree to fetch results
+
+### --branch
+
+The branch to get results for
+
+### --commit
+
+The tip of tree commit being tested. It needs to be the full commit hash.
+
+Unfortunately the Dashboard API doesn't support git tags as parameters yet.
+
+## Results actions
+
+### --action=summary
+
+Shows a numeric summary of the build, boot and test results.
+If `--action` is omitted, it will show the summary by default.
+
+Example:
+
+```sh
+kci-dev results --giturl 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git' --branch master --commit  d1486dca38afd08ca279ae94eb3a397f10737824 --action=summary
+```
+
+### --action=failed-builds
+
+List failed builds.
+
+Example:
+
+```sh
+kci-dev results --giturl 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git' --branch master --commit  d1486dca38afd08ca279ae94eb3a397f10737824 --action failed-builds
+```
+
+## Downloading logs
+
+`--download-logs` Download failed logs when used with `--action=failed-*` commands.
+
+Example:
+```sh
+kci-dev results --giturl 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git' --branch master --commit  d1486dca38afd08ca279ae94eb3a397f10737824 --action failed-builds --download-logs
+```
+
+
+
+

--- a/kcidev/libs/common.py
+++ b/kcidev/libs/common.py
@@ -34,3 +34,11 @@ def load_toml(settings):
         raise click.Abort()
 
     return config
+
+
+def kci_print(content):
+    click.echo(content)
+
+
+def kci_err(content):
+    click.secho(content, fg="red", err=True)

--- a/kcidev/main.py
+++ b/kcidev/main.py
@@ -4,7 +4,14 @@
 import click
 
 from kcidev.libs.common import *
-from kcidev.subcommands import checkout, commit, patch, maestro_results, testretry
+from kcidev.subcommands import (
+    checkout,
+    commit,
+    maestro_results,
+    patch,
+    results,
+    testretry,
+)
 
 
 @click.group(
@@ -20,18 +27,21 @@ from kcidev.subcommands import checkout, commit, patch, maestro_results, testret
 @click.option("--instance", help="API instance to use", required=False)
 @click.pass_context
 def cli(ctx, settings, instance):
-    ctx.obj = {"CFG": load_toml(settings)}
-    if instance:
-        ctx.obj["INSTANCE"] = instance
-    else:
-        ctx.obj["INSTANCE"] = ctx.obj["CFG"].get("default_instance")
-    if not ctx.obj["INSTANCE"]:
-        click.secho("No instance defined in settings or as argument", fg="red")
-        raise click.Abort()
-    if ctx.obj["INSTANCE"] not in ctx.obj["CFG"]:
-        click.secho(f"Instance {ctx.obj['INSTANCE']} not found in {settings}", fg="red")
-        raise click.Abort()
-    pass
+    if ctx.invoked_subcommand != "results":
+        ctx.obj = {"CFG": load_toml(settings)}
+        if instance:
+            ctx.obj["INSTANCE"] = instance
+        else:
+            ctx.obj["INSTANCE"] = ctx.obj["CFG"].get("default_instance")
+        if not ctx.obj["INSTANCE"]:
+            click.secho("No instance defined in settings or as argument", fg="red")
+            raise click.Abort()
+        if ctx.obj["INSTANCE"] not in ctx.obj["CFG"]:
+            click.secho(
+                f"Instance {ctx.obj['INSTANCE']} not found in {settings}", fg="red"
+            )
+            raise click.Abort()
+        pass
 
 
 def run():
@@ -40,6 +50,7 @@ def run():
     cli.add_command(patch.patch)
     cli.add_command(maestro_results.maestro_results)
     cli.add_command(testretry.testretry)
+    cli.add_command(results.results)
     cli()
 
 

--- a/kcidev/main.py
+++ b/kcidev/main.py
@@ -4,11 +4,11 @@
 import click
 
 from kcidev.libs.common import *
-from kcidev.subcommands import checkout, commit, patch, results, testretry
+from kcidev.subcommands import checkout, commit, patch, maestro_results, testretry
 
 
 @click.group(
-    help="Stand alone tool for Linux Kernel developers and maintainers to interact with KernelCI"
+    help="Stand alone tool for Linux Kernel developers and maintainers to interact with KernelCI."
 )
 @click.version_option("0.1.0", prog_name="kci-dev")
 @click.option(
@@ -38,7 +38,7 @@ def run():
     cli.add_command(checkout.checkout)
     cli.add_command(commit.commit)
     cli.add_command(patch.patch)
-    cli.add_command(results.results)
+    cli.add_command(maestro_results.maestro_results)
     cli.add_command(testretry.testretry)
     cli()
 

--- a/kcidev/subcommands/maestro_results.py
+++ b/kcidev/subcommands/maestro_results.py
@@ -72,7 +72,7 @@ def get_nodes(url, limit, offset, filter, field):
     print_nodes(nodes, field)
 
 
-@click.command(help="Get results")
+@click.command(help="Get results directly from KernelCI's Maestro")
 @click.option(
     "--nodeid",
     required=False,
@@ -109,7 +109,7 @@ def get_nodes(url, limit, offset, filter, field):
     help="Print only particular field(s) from node data",
 )
 @click.pass_context
-def results(ctx, nodeid, nodes, limit, offset, filter, field):
+def maestro_results(ctx, nodeid, nodes, limit, offset, filter, field):
     config = ctx.obj.get("CFG")
     instance = ctx.obj.get("INSTANCE")
     url = api_connection(config[instance]["api"])

--- a/kcidev/subcommands/results.py
+++ b/kcidev/subcommands/results.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import gzip
+import json
+import urllib
+
+import click
+import requests
+
+from kcidev.libs.common import *
+
+DASHBOARD_API = "https://dashboard.kernelci.org/api/"
+
+
+def fetch_from_api(endpoint, params):
+    base_url = urllib.parse.urljoin(DASHBOARD_API, endpoint)
+    try:
+        url = "{}?{}".format(base_url, urllib.parse.urlencode(params))
+        r = requests.get(url)
+    except:
+        click.secho(f"Failed to fetch from {DASHBOARD_API}.")
+        raise click.Abort()
+
+    return r.json()
+
+
+def cmd_summary(data):
+    kci_print(f"Builds: {data['buildsSummary']['builds']}")
+    kci_print(f"Boots: {data['bootStatusSummary']}")
+    kci_print(f"Tests: {data['testStatusSummary']}")
+
+
+def cmd_failed_builds(data, download_logs):
+    kci_print("Failed builds:")
+    for build in data["builds"]:
+        if not build["valid"]:
+            log_path = build["log_url"]
+            if download_logs:
+                try:
+                    log_gz = requests.get(build["log_url"])
+                    log = gzip.decompress(log_gz.content)
+                    log_file = f"{build['config_name']}-{build['architecture']}-{build['compiler']}.log"
+                    with open(log_file, mode="wb") as file:
+                        file.write(log)
+                    log_path = os.path.join(os.getcwd(), log_file)
+                except:
+                    kci_err(f"Failed to fetch log {log_file}).")
+                    pass
+
+            kci_print(
+                f"- config: {build['config_name']}; arch: {build['architecture']}"
+            )
+            kci_print(f"  compiler: {build['compiler']}")
+            kci_print(f"  config_url: {build['config_url']}")
+            kci_print(f"  log: {log_path}")
+            kci_print(f"  id: {build['id']}")
+
+
+def process_action(action, data, download_logs):
+    if action == None or action == "summary":
+        cmd_summary(data)
+    elif action == "failed-builds":
+        cmd_failed_builds(data, download_logs)
+
+
+def fetch_full_results(origin, giturl, branch, commit):
+    endpoint = f"tree/{commit}/full"
+    params = {
+        "origin": origin,
+        "git_url": giturl,
+        "git_branch": branch,
+        "commit": commit,
+    }
+
+    return fetch_from_api(endpoint, params)
+
+
+@click.command(help=" [Experimental] Get results from the dashboard")
+@click.option(
+    "--origin",
+    help="Select KCIDB origin",
+    default="maestro",
+)
+@click.option(
+    "--giturl",
+    help="Git URL of kernel tree ",
+    required=True,
+)
+@click.option(
+    "--branch",
+    help="Branch to get results for",
+    required=True,
+)
+@click.option(
+    "--commit",
+    help="Commit or tag to get results for",
+    required=True,
+)
+@click.option(
+    "--action",
+    help="Select desired results action",
+)
+@click.option(
+    "--download-logs",
+    is_flag=True,
+    help="Select desired results action",
+)
+@click.pass_context
+def results(ctx, origin, giturl, branch, commit, action, download_logs):
+    data = fetch_full_results(origin, giturl, branch, commit)
+    process_action(action, data, download_logs)
+
+
+if __name__ == "__main__":
+    main_kcidev()

--- a/tests/test_kcidev.py
+++ b/tests/test_kcidev.py
@@ -46,7 +46,7 @@ def test_kcidev_patch_help():
 
 
 def test_kcidev_results_help():
-    command = ["poetry", "run", "kci-dev", "results", "--help"]
+    command = ["poetry", "run", "kci-dev", "maestro-results", "--help"]
     result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
     print("returncode: " + str(result.returncode))
     print("#### stdout ####")
@@ -85,7 +85,7 @@ def test_kcidev_results_tests():
         "kci-dev",
         "--instance",
         "staging",
-        "results",
+        "maestro-results",
         "--nodeid",
         "65a1355ee98651d0fe81e41d",
     ]


### PR DESCRIPTION
Add PoC for `kci-dev results` from the [Dashboard API](https://github.com/kernelci/dashboard/blob/main/backend/kernelCI_app/urls.py).

See the `docs/results.md` for details about this command. For the time being, it will be experimental as we refine how together with kernel developers how they are going to be using `kci-dev`.

There is a know slowdown in the API due to https://github.com/kernelci/dashboard/issues/661.

Related to #57 
