### PR TITLE
results: improve output of the summary cmd

### DIFF
--- a/kcidev/libs/common.py
+++ b/kcidev/libs/common.py
@@ -42,3 +42,19 @@ def kci_print(content):
 
 def kci_err(content):
     click.secho(content, fg="red", err=True)
+
+
+def kci_msg_nonl(content):
+    click.echo(content, nl=False)
+
+
+def kci_msg_green_nonl(content):
+    click.secho(content, fg="green", nl=False)
+
+
+def kci_msg_red_nonl(content):
+    click.secho(content, fg="red", nl=False)
+
+
+def kci_msg_yellow_nonl(content):
+    click.secho(content, fg="bright_yellow", nl=False)


### PR DESCRIPTION
Make the output easir to understand and parse. Before we were just printing json.


``` 
kcidev > poetry run kci-dev results  --commit 4b281055ccfba614e9358cac95fc81a1e79a5d7e --giturl 'https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git' --branch linux-5.15.y
pass/fail/inconclusive
builds:	29/1/0
boots:	411/67/22
tests:	2584/347/191
```