### PR TITLE
Refactor 'results --action=builds' 

### DIFF
--- a/docs/results.md
+++ b/docs/results.md
@@ -33,6 +33,10 @@ Unfortunately the Dashboard API doesn't support git tags as parameters yet.
 
 Return results for the latest commit for the tree.
 
+### --status
+
+Filter results by the status: "all", "pass", "fail" or "inconclusive"
+
 ## Results actions
 
 ### --action=trees
@@ -56,14 +60,14 @@ Example:
 kci-dev results --giturl 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git' --branch master --commit  d1486dca38afd08ca279ae94eb3a397f10737824 --action=summary
 ```
 
-### --action=failed-builds
+### --action=builds
 
-List failed builds.
+List builds.
 
 Example:
 
 ```sh
-kci-dev results --giturl 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git' --branch master --commit  d1486dca38afd08ca279ae94eb3a397f10737824 --action failed-builds
+kci-dev results --giturl 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git' --branch master --commit  d1486dca38afd08ca279ae94eb3a397f10737824 --action builds
 ```
 
 ## Downloading logs

--- a/kcidev/libs/common.py
+++ b/kcidev/libs/common.py
@@ -58,3 +58,7 @@ def kci_msg_red_nonl(content):
 
 def kci_msg_yellow_nonl(content):
     click.secho(content, fg="bright_yellow", nl=False)
+
+
+def kci_msg_cyan_nonl(content):
+    click.secho(content, fg="cyan", nl=False)

--- a/kcidev/libs/common.py
+++ b/kcidev/libs/common.py
@@ -36,7 +36,7 @@ def load_toml(settings):
     return config
 
 
-def kci_print(content):
+def kci_msg(content):
     click.echo(content)
 
 

--- a/kcidev/subcommands/results.py
+++ b/kcidev/subcommands/results.py
@@ -78,7 +78,7 @@ def sum_inconclusive_results(results):
 
 
 def cmd_summary(data):
-    kci_print("pass/fail/inconclusive")
+    kci_msg("pass/fail/inconclusive")
 
     builds = data["buildsSummary"]["builds"]
     print_summary("builds", builds["valid"], builds["invalid"], builds["null"])
@@ -100,13 +100,13 @@ def cmd_list_trees(origin):
     trees = fetch_tree_fast(origin)
     for t in trees:
         kci_msg_green_nonl(f"- {t['tree_name']}/{t['git_repository_branch']}:\n")
-        kci_print(f"  giturl: {t['git_repository_url']}")
-        kci_print(f"  latest: {t['git_commit_hash']} ({t['git_commit_name']})")
-        kci_print(f"  latest: {t['start_time']}")
+        kci_msg(f"  giturl: {t['git_repository_url']}")
+        kci_msg(f"  latest: {t['git_commit_hash']} ({t['git_commit_name']})")
+        kci_msg(f"  latest: {t['start_time']}")
 
 
 def cmd_failed_builds(data, download_logs):
-    kci_print("Failed builds:")
+    kci_msg("Failed builds:")
     for build in data["builds"]:
         if not build["valid"]:
             log_path = build["log_url"]
@@ -128,11 +128,11 @@ def cmd_failed_builds(data, download_logs):
             kci_msg_cyan_nonl(build["architecture"])
             kci_msg_nonl(" compiler: ")
             kci_msg_cyan_nonl(build['compiler'])
-            kci_print("")
+            kci_msg("")
 
-            kci_print(f"  config_url: {build['config_url']}")
-            kci_print(f"  log: {log_path}")
-            kci_print(f"  id: {build['id']}")
+            kci_msg(f"  config_url: {build['config_url']}")
+            kci_msg(f"  log: {log_path}")
+            kci_msg(f"  id: {build['id']}")
 
 
 @click.command(help=" [Experimental] Get results from the dashboard")

--- a/kcidev/subcommands/results.py
+++ b/kcidev/subcommands/results.py
@@ -117,7 +117,7 @@ def cmd_failed_builds(data, commit, download_logs):
                     log_file = f"{build['config_name']}-{build['architecture']}-{build['compiler']}-{commit}.log"
                     with open(log_file, mode="wb") as file:
                         file.write(log)
-                    log_path = os.path.join(os.getcwd(), log_file)
+                    log_path = "file://" + os.path.join(os.getcwd(), log_file)
                 except:
                     kci_err(f"Failed to fetch log {log_file}).")
                     pass

--- a/kcidev/subcommands/results.py
+++ b/kcidev/subcommands/results.py
@@ -105,7 +105,7 @@ def cmd_list_trees(origin):
         kci_msg(f"  latest: {t['start_time']}")
 
 
-def cmd_failed_builds(data, download_logs):
+def cmd_failed_builds(data, commit, download_logs):
     kci_msg("Failed builds:")
     for build in data["builds"]:
         if not build["valid"]:
@@ -114,7 +114,7 @@ def cmd_failed_builds(data, download_logs):
                 try:
                     log_gz = requests.get(build["log_url"])
                     log = gzip.decompress(log_gz.content)
-                    log_file = f"{build['config_name']}-{build['architecture']}-{build['compiler']}.log"
+                    log_file = f"{build['config_name']}-{build['architecture']}-{build['compiler']}-{commit}.log"
                     with open(log_file, mode="wb") as file:
                         file.write(log)
                     log_path = os.path.join(os.getcwd(), log_file)
@@ -186,7 +186,7 @@ def results(ctx, origin, giturl, branch, commit, action, download_logs, latest):
         if latest:
             commit = get_latest_commit(origin, giturl, branch)
         data = fetch_full_results(origin, giturl, branch, commit)
-        cmd_failed_builds(data, download_logs)
+        cmd_failed_builds(data, commit, download_logs)
 
 
 if __name__ == "__main__":

--- a/kcidev/subcommands/results.py
+++ b/kcidev/subcommands/results.py
@@ -122,10 +122,14 @@ def cmd_failed_builds(data, download_logs):
                     kci_err(f"Failed to fetch log {log_file}).")
                     pass
 
-            kci_print(
-                f"- config: {build['config_name']}; arch: {build['architecture']}"
-            )
-            kci_print(f"  compiler: {build['compiler']}")
+            kci_msg_nonl("- config:")
+            kci_msg_cyan_nonl(build["config_name"])
+            kci_msg_nonl(" arch: ")
+            kci_msg_cyan_nonl(build["architecture"])
+            kci_msg_nonl(" compiler: ")
+            kci_msg_cyan_nonl(build['compiler'])
+            kci_print("")
+
             kci_print(f"  config_url: {build['config_url']}")
             kci_print(f"  log: {log_path}")
             kci_print(f"  id: {build['id']}")

--- a/kcidev/subcommands/results.py
+++ b/kcidev/subcommands/results.py
@@ -105,34 +105,54 @@ def cmd_list_trees(origin):
         kci_msg(f"  latest: {t['start_time']}")
 
 
-def cmd_failed_builds(data, commit, download_logs):
-    kci_msg("Failed builds:")
+def cmd_builds(data, commit, download_logs, status):
+    if status == "inconclusive":
+        kci_msg("No information about inconclusive builds.")
+        return
+
     for build in data["builds"]:
-        if not build["valid"]:
-            log_path = build["log_url"]
-            if download_logs:
-                try:
-                    log_gz = requests.get(build["log_url"])
-                    log = gzip.decompress(log_gz.content)
-                    log_file = f"{build['config_name']}-{build['architecture']}-{build['compiler']}-{commit}.log"
-                    with open(log_file, mode="wb") as file:
-                        file.write(log)
-                    log_path = "file://" + os.path.join(os.getcwd(), log_file)
-                except:
-                    kci_err(f"Failed to fetch log {log_file}).")
-                    pass
+        if build["valid"] == None:
+            continue
 
-            kci_msg_nonl("- config:")
-            kci_msg_cyan_nonl(build["config_name"])
-            kci_msg_nonl(" arch: ")
-            kci_msg_cyan_nonl(build["architecture"])
-            kci_msg_nonl(" compiler: ")
-            kci_msg_cyan_nonl(build['compiler'])
-            kci_msg("")
+        if not status == "all":
+            if build["valid"] == (status == "fail"):
+                continue
 
-            kci_msg(f"  config_url: {build['config_url']}")
-            kci_msg(f"  log: {log_path}")
-            kci_msg(f"  id: {build['id']}")
+            if not build["valid"] == (status == "pass"):
+                continue
+
+        log_path = build["log_url"]
+        if download_logs:
+            try:
+                log_gz = requests.get(build["log_url"])
+                log = gzip.decompress(log_gz.content)
+                log_file = f"{build['config_name']}-{build['architecture']}-{build['compiler']}-{commit}.log"
+                with open(log_file, mode="wb") as file:
+                    file.write(log)
+                log_path = "file://" + os.path.join(os.getcwd(), log_file)
+            except:
+                kci_err(f"Failed to fetch log {log_file}).")
+                pass
+
+        kci_msg_nonl("- config:")
+        kci_msg_cyan_nonl(build["config_name"])
+        kci_msg_nonl(" arch: ")
+        kci_msg_cyan_nonl(build["architecture"])
+        kci_msg_nonl(" compiler: ")
+        kci_msg_cyan_nonl(build["compiler"])
+        kci_msg("")
+
+        kci_msg_nonl("  status:")
+        if build["valid"]:
+            kci_msg_green_nonl("PASS")
+        else:
+            kci_msg_red_nonl("FAIL")
+        kci_msg("")
+
+        kci_msg(f"  config_url: {build['config_url']}")
+        kci_msg(f"  log: {log_path}")
+        kci_msg(f"  id: {build['id']}")
+        kci_msg("")
 
 
 @click.command(help=" [Experimental] Get results from the dashboard")
@@ -167,8 +187,13 @@ def cmd_failed_builds(data, commit, download_logs):
     is_flag=True,
     help="Select latest results available",
 )
+@click.option(
+    "--status",
+    help="Status of test result: all, pass, fail, inconclusive",
+    default="all",
+)
 @click.pass_context
-def results(ctx, origin, giturl, branch, commit, action, download_logs, latest):
+def results(ctx, origin, giturl, branch, commit, action, download_logs, latest, status):
     if action == None or action == "summary":
         if not giturl or not branch or not ((commit != None) ^ latest):
             kci_err("--giturl AND --branch AND (--commit XOR --latest) are required")
@@ -179,14 +204,17 @@ def results(ctx, origin, giturl, branch, commit, action, download_logs, latest):
         cmd_summary(data)
     elif action == "trees":
         cmd_list_trees(origin)
-    elif action == "failed-builds":
+    elif action == "builds":
         if not giturl or not branch or not ((commit != None) ^ latest):
             kci_err("--giturl AND --branch AND (--commit XOR --latest) are required")
             raise click.Abort()
         if latest:
             commit = get_latest_commit(origin, giturl, branch)
         data = fetch_full_results(origin, giturl, branch, commit)
-        cmd_failed_builds(data, commit, download_logs)
+        cmd_builds(data, commit, download_logs, status)
+    else:
+        kci_err(f"action '{action}' does not exist.")
+        raise click.Abort()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Improve usability by:
* showing all builds, not only failing builds
* filtering for pass or fail
* color highlight to output
* add commit hash to log file name to avoid clash with files from a different revision.