### PR TITLE
pypi-publish: publish only with a production tag

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -1,8 +1,9 @@
 name: Publish package to PyPI
 
 on:
-  release:
-    types: [published]
+  push:
+    tags:
+      - "v*.*.*"
 
 jobs:
   pypi_publish:


### PR DESCRIPTION
"on: release:" workflow catches also dev release, but dev release are published only on testing PyPI, at the moment