### PR TITLE
fix(bisect.py): Fix initial tree creation and params rename

### DIFF
--- a/docs/checkout.md
+++ b/docs/checkout.md
@@ -10,21 +10,21 @@ This might be useful in several cases:
 - You want to create snapshot of the test results on specific tags (releases, etc).
 - Use this command for regression bisection
 
-This command can execute all tests configured for particular tree/branch, or you can provide jobfilter to execute specific tests and builds.
+This command can execute all tests configured for particular tree/branch, or you can provide job-filter to execute specific tests and builds.
 
 Example:
 ```sh
-kci-dev checkout --giturl https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --branch master --commit f06021a18fcf8d8a1e79c5e0a8ec4eb2b038e153 --jobfilter "kbuild-gcc-12-x86"
+kci-dev checkout --giturl https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --branch master --commit f06021a18fcf8d8a1e79c5e0a8ec4eb2b038e153 --job-filter "kbuild-gcc-12-x86"
 ```
 
 Where:
 - `giturl` is the URL of the git repository to test.
 - `branch` is the branch of the git repository to test.
 - `commit` is the commit hash to test.
-- `jobfilter` is the job filter to use for the test (optional parameter)
-- `platformfilter` is the platform filter (usually it is name of hardware platform for group of devices) to use for the test (optional parameter)
+- `job-filter` is the job filter to use for the test (optional parameter)
+- `platform-filter` is the platform filter (usually it is name of hardware platform for group of devices) to use for the test (optional parameter)
 
-To figure out correct jobfilter and platformfilter, you need to check test json node. For example:
+To figure out correct job-filter and platform-filter, you need to check test json node. For example:
 ```json
 {
   "id": "670f0c27493b6b8188c7667c",
@@ -81,7 +81,7 @@ To figure out correct jobfilter and platformfilter, you need to check test json 
     "kernel_type": "image"
   },
   "debug": null,
-  "jobfilter": null,
+  "job-filter": null,
   "platform_filter": null,
   "created": "2024-10-16T00:43:19.079000",
   "updated": "2024-10-16T02:22:58.113000",
@@ -94,9 +94,9 @@ To figure out correct jobfilter and platformfilter, you need to check test json 
 }
 ```
 
-In this example, the jobfilter is `tast-mm-misc-arm64-qualcomm` for test, if you look into path, you can figure out also build job named and the platformfilter is `kbuild-gcc-12-arm64-chromeos-qualcomm` and in data/platform: `sc7180-trogdor-lazor-limozeen`. So complete command to test this job would be:
+In this example, the job-filter is `tast-mm-misc-arm64-qualcomm` for test, if you look into path, you can figure out also build job named and the platform-filter is `kbuild-gcc-12-arm64-chromeos-qualcomm` and in data/platform: `sc7180-trogdor-lazor-limozeen`. So complete command to test this job would be:
 ```sh
-kci-dev checkout --giturl https://github.com/kernelci/linux.git --branch staging-mainline --commit c862449c840a37bbe797a0b719881449beac75ca --jobfilter tast-mm-misc-arm64-qualcomm --jobfilter kbuild-gcc-12-arm64-chromeos-qualcomm --platformfilter sc7180-trogdor-lazor-limozeen
+kci-dev checkout --giturl https://github.com/kernelci/linux.git --branch staging-mainline --commit c862449c840a37bbe797a0b719881449beac75ca --job-filter tast-mm-misc-arm64-qualcomm --job-filter kbuild-gcc-12-arm64-chromeos-qualcomm --platform-filter sc7180-trogdor-lazor-limozeen
 ```
 
 Other options:
@@ -111,7 +111,7 @@ Additionally, you can use --watch option to watch the progress of the test.
 
 After executing the command, you will see the output similar to the following:
 ```sh
-./kci-dev.py checkout --giturl https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --branch master --tipoftree --jobfilter baseline-nfs-arm64-qualcomm --jobfilter kbuild-gcc-12-arm64-chromeos-qualcomm --watch
+./kci-dev.py checkout --giturl https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --branch master --tipoftree --job-filter baseline-nfs-arm64-qualcomm --job-filter kbuild-gcc-12-arm64-chromeos-qualcomm --watch
 api connect: https://staging.kernelci.org:9100/
 Retrieving latest commit on tree: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git branch: master
 Commit to checkout: d3d1556696c1a993eec54ac585fe5bf677e07474
@@ -170,7 +170,7 @@ Together with --watch option, you can use --test option to wait for particular t
 
 For example:
 ```sh
-kci-dev.py checkout --giturl https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --branch master --tipoftree --jobfilter baseline-nfs-arm64-qualcomm --jobfilter kbuild-gcc-12-arm64-chromeos-qualcomm --platformfilter sc7180-trogdor-kingoftown --watch --test crit
+kci-dev.py checkout --giturl https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git --branch master --tipoftree --job-filter baseline-nfs-arm64-qualcomm --job-filter kbuild-gcc-12-arm64-chromeos-qualcomm --platform-filter sc7180-trogdor-kingoftown --watch --test crit
 ```
 
 This command will wait for the test results of the test with the name `crit`.  

--- a/kcidev/subcommands/bisect.py
+++ b/kcidev/subcommands/bisect.py
@@ -29,8 +29,8 @@ default_state = {
     "good": "",
     "bad": "",
     "history": [],
-    "jobfilter": [],
-    "platformfilter": [],
+    "job_filter": [],
+    "platform_filter": [],
     "test": "",
     "workdir": "",
     "bisect_init": False,
@@ -59,8 +59,8 @@ def print_state(state):
     click.secho("bad: " + state["bad"], fg="green")
     click.secho("retryfail: " + str(state["retryfail"]), fg="green")
     click.secho("history: " + str(state["history"]), fg="green")
-    click.secho("jobfilter: " + str(state["jobfilter"]), fg="green")
-    click.secho("platformfilter: " + str(state["platformfilter"]), fg="green")
+    click.secho("job_filter: " + str(state["job_filter"]), fg="green")
+    click.secho("platform_filter: " + str(state["platform_filter"]), fg="green")
     click.secho("test: " + state["test"], fg="green")
     click.secho("workdir: " + state["workdir"], fg="green")
     click.secho("bisect_init: " + str(state["bisect_init"]), fg="green")
@@ -170,12 +170,12 @@ def bisection_loop(state):
         commit,
         "--watch",
     ]
-    # jobfilter is array, so we need to add each element as a separate argument
-    for job in state["jobfilter"]:
-        cmd.append("--jobfilter")
+    # job_filter is array, so we need to add each element as a separate argument
+    for job in state["job_filter"]:
+        cmd.append("--job_filter")
         cmd.append(job)
-    for platform in state["platformfilter"]:
-        cmd.append("--platformfilter")
+    for platform in state["platform_filter"]:
+        cmd.append("--platform_filter")
         cmd.append(platform)
     result = kcidev_exec(cmd)
     try:
@@ -215,8 +215,8 @@ def bisection_loop(state):
 @click.option("--workdir", help="define the repository origin", default="kcidev-src")
 @click.option("--ignorestate", help="ignore save state", is_flag=True)
 @click.option("--statefile", help="state file", default="state.json")
-@click.option("--jobfilter", help="filter the job", multiple=True)
-@click.option("--platformfilter", help="filter the platform", multiple=True)
+@click.option("--job-filter", help="filter the job", multiple=True)
+@click.option("--platform-filter", help="filter the platform", multiple=True)
 @click.option("--test", help="Test expected to fail")
 
 # test
@@ -231,8 +231,8 @@ def bisect(
     workdir,
     ignorestate,
     statefile,
-    jobfilter,
-    platformfilter,
+    job_filter,
+    platform_filter,
     test,
 ):
     config = ctx.obj.get("CFG")
@@ -255,11 +255,11 @@ def bisect(
         if not bad:
             click.secho("--bad is required", fg="red")
             return
-        if not jobfilter:
-            click.secho("--jobfilter is required", fg="red")
+        if not job_filter:
+            click.secho("--job_filter is required", fg="red")
             return
-        if not platformfilter:
-            click.secho("--platformfilter is required", fg="red")
+        if not platform_filter:
+            click.secho("--platform_filter is required", fg="red")
             return
         if not test:
             click.secho("--test is required", fg="red")
@@ -270,8 +270,8 @@ def bisect(
         state["good"] = good
         state["bad"] = bad
         state["retryfail"] = retryfail
-        state["jobfilter"] = jobfilter
-        state["platformfilter"] = platformfilter
+        state["job_filter"] = job_filter
+        state["platform_filter"] = platform_filter
         state["test"] = test
         state["workdir"] = workdir
         update_tree(workdir, branch, giturl)

--- a/kcidev/subcommands/bisect.py
+++ b/kcidev/subcommands/bisect.py
@@ -133,6 +133,20 @@ def init_bisect(state):
     return commitid
 
 
+def update_tree(workdir, branch, giturl):
+    if not os.path.exists(workdir):
+        click.secho(
+            "Cloning repository (this might take significant time!)", fg="green"
+        )
+        repo = Repo.clone_from(giturl, workdir)
+        repo.git.checkout(branch)
+    else:
+        click.secho("Pulling repository", fg="green")
+        repo = Repo(workdir)
+        repo.git.checkout(branch)
+        repo.git.pull()
+
+
 def bisection_loop(state):
     olddir = os.getcwd()
     os.chdir(state["workdir"])
@@ -258,20 +272,11 @@ def bisect(
         state["platformfilter"] = platformfilter
         state["test"] = test
         state["workdir"] = workdir
+        update_tree(workdir, branch, giturl)
         save_state(state, state_file)
     else:
         print_state(state)
-
-    # if workdir doesnt exist, clone the repository
-    if not os.path.exists(workdir):
-        click.secho("Cloning repository", fg="green")
-        repo = Repo.clone_from(giturl, workdir)
-        repo.git.checkout(branch)
-    else:
-        click.secho("Pulling repository", fg="green")
-        repo = Repo(workdir)
-        repo.git.checkout(branch)
-        repo.git.pull()
+        update_tree(workdir, branch, giturl)
 
     if not state["bisect_init"]:
         state["next_commit"] = init_bisect(state)

--- a/kcidev/subcommands/bisect.py
+++ b/kcidev/subcommands/bisect.py
@@ -76,7 +76,9 @@ def git_exec_getcommit(cmd):
     click.secho("Executing git command: " + " ".join(cmd), fg="green")
     result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     if result.returncode != 0:
-        click.secho("git command return failed", fg="red")
+        click.secho("git command return failed. Error:", fg="red")
+        click.secho(result.stderr, fg="red")
+        click.secho(result.stdout, fg="red")
         sys.exit(1)
     lines = result.stdout.split(b"\n")
     if len(lines) < 2:


### PR DESCRIPTION
1)If linux tree source code doesn't exist (workdir), bisection will fail due wrong sequence of commands.
2)Change parameter names from platformfilter and jobfilter to job-filter and platform-filter 