### PR TITLE
Turn results --action into subcommands

### DIFF
--- a/docs/results.md
+++ b/docs/results.md
@@ -9,7 +9,36 @@ description = 'Fetch results from the KernelCI ecosystem.'
 > KNOWN ISSUE: The Dashboard endpoint we are using returns a file of a few megabytes in size, so download may take
 a few seconds, slowing down your usage of `kci-dev results`. We are working on [it](https://github.com/kernelci/dashboard/issues/661).
 
-## Base parameters
+
+## Commands
+
+### trees
+
+```sh
+kci-dev results trees
+```
+
+### summary
+
+Shows a numeric summary of the build, boot and test results.
+
+Example:
+
+```sh
+kci-dev results summary --giturl 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git' --branch master --commit  d1486dca38afd08ca279ae94eb3a397f10737824
+```
+
+### builds
+
+List builds.
+
+Example:
+
+```sh
+kci-dev results builds --giturl 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git' --branch master --commit  d1486dca38afd08ca279ae94eb3a397f10737824
+```
+
+## Common parameters
 
 ### --origin
 
@@ -37,25 +66,41 @@ Unfortunately the Dashboard API doesn't support git tags as parameters yet.
 
 Return results for the latest commit for the tree.
 
+Example:
+```sh
+kci-dev results builds --giturl 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git' --branch master  --latest
+```
+
 ### --status
 
-Filter results by the status: "all", "pass", "fail" or "inconclusive"
-
-## Results actions
-
-
-List all available trees for a given origin.
+Filter results by the status: "all", "pass", "fail" or "inconclusive".
+(available for subcommand `build`)
 
 Example:
+```sh
+kci-dev results builds --giturl 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git' --branch master  --latest --status=fail
+```
+
+## --download-logs
+
+Automatically download logs for results listed.
+(available for subcommand `build`)
+
+Example:
+```sh
+kci-dev results build --giturl 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git' --branch master --commit  d1486dca38afd08ca279ae94eb3a397f10737824 --download-logs
+```
+
 
 ### without arguments
 
-If used without arguments, `kci-dev results` will get KernelCI status of local checked out git repository
+If used without arguments, `kci-dev results` subcommands will get KernelCI status
+of local checked out git repository for commands that require a giturl and branch.
 In the following example, kci-dev is used on a local linux repository folder
 This command work with every linux repository supported by KernelCI
 
 ```sh
-linux git:(master)$ kci-dev results
+linux git:(master)$ kci-dev results summary
 git folder: None
 tree: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git
 branch: master
@@ -69,7 +114,7 @@ tests:  7858/6903/654
 
 ### --git-folder=\<local repository path\>
 
-Get results automatically from a folder with a local linux repository 
+Get results automatically from a folder with a local linux repository.
 
 ```sh
 kci-dev git:(master)$ kci-dev results --git-folder ../linux
@@ -83,43 +128,3 @@ builds: 46/0/0
 boots:  580/48/8
 tests:  7858/6903/654
 ```
-
-### --action=trees
-
-```sh
-kci-dev results --action=trees
-```
-
-### --action=summary
-
-Shows a numeric summary of the build, boot and test results.
-If `--action` is omitted, it will show the summary by default.
-
-Example:
-
-```sh
-kci-dev results --giturl 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git' --branch master --commit  d1486dca38afd08ca279ae94eb3a397f10737824 --action=summary
-```
-
-### --action=builds
-
-List builds.
-
-Example:
-
-```sh
-kci-dev results --giturl 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git' --branch master --commit  d1486dca38afd08ca279ae94eb3a397f10737824 --action builds
-```
-
-## Downloading logs
-
-`--download-logs` Download failed logs when used with `--action=failed-*` commands.
-
-Example:
-```sh
-kci-dev results --giturl 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git' --branch master --commit  d1486dca38afd08ca279ae94eb3a397f10737824 --action failed-builds --download-logs
-```
-
-
-
-

--- a/kcidev/subcommands/results.py
+++ b/kcidev/subcommands/results.py
@@ -237,6 +237,14 @@ def cmd_builds(data, commit, download_logs, status):
         kci_msg("")
 
 
+def set_giturl_branch_commit(origin, giturl, branch, commit, latest, git_folder):
+    if not giturl or not branch or not ((commit != None) ^ latest):
+        giturl, branch, commit = get_folder_repository(git_folder)
+    if latest:
+        commit = get_latest_commit(origin, giturl, branch)
+    return giturl, branch, commit
+
+
 @click.command(help=" [Experimental] Get results from the dashboard")
 @click.option(
     "--origin",
@@ -294,19 +302,17 @@ def results(
     status,
 ):
     if action == None or action == "summary":
-        if not giturl or not branch or not ((commit != None) ^ latest):
-            giturl, branch, commit = get_folder_repository(git_folder)
-        if latest:
-            commit = get_latest_commit(origin, giturl, branch)
+        giturl, branch, commit = set_giturl_branch_commit(
+                origin, giturl, branch, commit, latest, git_folder
+            )
         data = fetch_full_results(origin, giturl, branch, commit)
         cmd_summary(data)
     elif action == "trees":
         cmd_list_trees(origin)
     elif action == "builds":
-        if not giturl or not branch or not ((commit != None) ^ latest):
-            giturl, branch, commit = get_folder_repository(git_folder)
-        if latest:
-            commit = get_latest_commit(origin, giturl, branch)
+        giturl, branch, commit = set_giturl_branch_commit(
+                origin, giturl, branch, commit, latest, git_folder
+            )
         data = fetch_full_results(origin, giturl, branch, commit)
         cmd_builds(data, commit, download_logs, status)
     else:

--- a/kcidev/subcommands/sub.py
+++ b/kcidev/subcommands/sub.py
@@ -1,0 +1,53 @@
+import click
+
+
+# Main CLI group
+@click.group()
+def cli():
+    """kci-dev: A tool for KernelCI development."""
+    pass
+
+
+# Subgroup for 'maestro'
+@cli.group()
+def maestro():
+    """Commands related to maestro."""
+    pass
+
+
+# Subcommands under 'maestro'
+@maestro.command()
+def test_checkout():
+    """Test the checkout process."""
+    click.echo("Running maestro test-checkout...")
+
+
+@maestro.command()
+def test_patch():
+    """Test a patch."""
+    click.echo("Running maestro test-patch...")
+
+
+# Subgroup for 'results'
+@cli.group()
+def results():
+    """Commands related to results."""
+    pass
+
+
+# Subcommands under 'results'
+@results.command()
+def summary():
+    """Display a summary of results."""
+    click.echo("Displaying results summary...")
+
+
+@results.command()
+def details():
+    """Display detailed results."""
+    click.echo("Displaying detailed results...")
+
+
+# Entry point
+if __name__ == "__main__":
+    cli()


### PR DESCRIPTION
As discussed in #65, fix 'results' to use subcommands:

    $ kci-dev trees
    $ kci-dev summary
    $ kci-dev builds

This is much cleaner interface and a request from users.