### PR TITLE
config: Fix config subcommand asking for config and support current f…

### DIFF
--- a/kcidev/libs/common.py
+++ b/kcidev/libs/common.py
@@ -38,11 +38,13 @@ def load_toml(settings, subcommand):
             config = tomllib.load(f)
         return config
 
-    if not config:
-        kci_err(
-            f"No config file found, please use `kci-dev config` to create a config file"
-        )
-        raise click.Abort()
+    # config and results subcommand work without a config file
+    if subcommand != "config" and subcommand != "results":
+        if not config:
+            kci_err(
+                f"No config file found, please use `kci-dev config` to create a config file"
+            )
+            raise click.Abort()
 
     return config
 

--- a/kcidev/main.py
+++ b/kcidev/main.py
@@ -30,9 +30,9 @@ from kcidev.subcommands import (
 @click.pass_context
 def cli(ctx, settings, instance):
     subcommand = ctx.invoked_subcommand
-    if subcommand != "results":
-        ctx.obj = {"CFG": load_toml(settings, subcommand)}
-        ctx.obj["SETTINGS"] = settings
+    ctx.obj = {"CFG": load_toml(settings, subcommand)}
+    ctx.obj["SETTINGS"] = settings
+    if subcommand != "results" and subcommand != "config":
         if instance:
             ctx.obj["INSTANCE"] = instance
         else:

--- a/kcidev/subcommands/config.py
+++ b/kcidev/subcommands/config.py
@@ -51,7 +51,7 @@ def add_config(fpath):
     )
     if os.path.exists(poetry_example_configuration):
         config = True
-        if not os.path.exists(dpath):
+        if not os.path.exists(dpath) and dpath != "":
             # copy config
             os.makedirs(dpath)
         shutil.copyfile(poetry_example_configuration, fpath)
@@ -62,7 +62,7 @@ def add_config(fpath):
     )
     if os.path.exists(pypi_example_configuration):
         config = True
-        if not os.path.exists(dpath):
+        if not os.path.exists(dpath) and dpath != "":
             # copy config
             os.makedirs(dpath)
         shutil.copyfile(poetry_example_configuration, fpath)

--- a/tests/test_kcidev.py
+++ b/tests/test_kcidev.py
@@ -5,11 +5,16 @@ from subprocess import PIPE, run
 import git
 import pytest
 
+from kcidev.subcommands.config import add_config
 
-def test_prepare():
+
+@pytest.fixture(scope="session")
+def kcidev_config(tmpdir_factory):
+    file = tmpdir_factory.mktemp("config").join(".kci-dev.toml")
     # prepare enviroment
-    os.system("cp .kci-dev.toml.example .kci-dev.toml")
-    assert os.path.exists(".kci-dev.toml")
+    command = ["poetry", "run", "kci-dev", "config", "--file-path", file]
+    result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    return file
 
 
 def test_kcidev_help():
@@ -23,66 +28,108 @@ def test_kcidev_help():
     assert result.returncode == 0
 
 
-def test_kcidev_commit_help():
-    command = ["poetry", "run", "kci-dev", "commit", "--help"]
-    result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-    print("returncode: " + str(result.returncode))
-    print("#### stdout ####")
-    print(result.stdout)
-    print("#### stderr ####")
-    print(result.stderr)
-    assert result.returncode == 0
-
-
-def test_kcidev_patch_help():
-    command = ["poetry", "run", "kci-dev", "patch", "--help"]
-    result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-    print("returncode: " + str(result.returncode))
-    print("#### stdout ####")
-    print(result.stdout)
-    print("#### stderr ####")
-    print(result.stderr)
-    assert result.returncode == 0
-
-
-def test_kcidev_results_help():
-    command = ["poetry", "run", "kci-dev", "maestro-results", "--help"]
-    result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-    print("returncode: " + str(result.returncode))
-    print("#### stdout ####")
-    print(result.stdout)
-    print("#### stderr ####")
-    print(result.stderr)
-    assert result.returncode == 0
-
-
-def test_kcidev_testretry_help():
-    command = ["poetry", "run", "kci-dev", "testretry", "--help"]
-    result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-    print("returncode: " + str(result.returncode))
-    print("#### stdout ####")
-    print(result.stdout)
-    print("#### stderr ####")
-    print(result.stderr)
-    assert result.returncode == 0
-
-
-def test_kcidev_checkout_help():
-    command = ["poetry", "run", "kci-dev", "checkout", "--help"]
-    result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
-    print("returncode: " + str(result.returncode))
-    print("#### stdout ####")
-    print(result.stdout)
-    print("#### stderr ####")
-    print(result.stderr)
-    assert result.returncode == 0
-
-
-def test_kcidev_results_tests():
+def test_kcidev_commit_help(kcidev_config):
     command = [
         "poetry",
         "run",
         "kci-dev",
+        "--settings",
+        kcidev_config,
+        "commit",
+        "--help",
+    ]
+    result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    print("returncode: " + str(result.returncode))
+    print("#### stdout ####")
+    print(result.stdout)
+    print("#### stderr ####")
+    print(result.stderr)
+    assert result.returncode == 0
+
+
+def test_kcidev_patch_help(kcidev_config):
+    command = [
+        "poetry",
+        "run",
+        "kci-dev",
+        "--settings",
+        kcidev_config,
+        "patch",
+        "--help",
+    ]
+    result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    print("returncode: " + str(result.returncode))
+    print("#### stdout ####")
+    print(result.stdout)
+    print("#### stderr ####")
+    print(result.stderr)
+    assert result.returncode == 0
+
+
+def test_kcidev_results_help(kcidev_config):
+    command = [
+        "poetry",
+        "run",
+        "kci-dev",
+        "--settings",
+        kcidev_config,
+        "maestro-results",
+        "--help",
+    ]
+    result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    print("returncode: " + str(result.returncode))
+    print("#### stdout ####")
+    print(result.stdout)
+    print("#### stderr ####")
+    print(result.stderr)
+    assert result.returncode == 0
+
+
+def test_kcidev_testretry_help(kcidev_config):
+    command = [
+        "poetry",
+        "run",
+        "kci-dev",
+        "--settings",
+        kcidev_config,
+        "testretry",
+        "--help",
+    ]
+    result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    print("returncode: " + str(result.returncode))
+    print("#### stdout ####")
+    print(result.stdout)
+    print("#### stderr ####")
+    print(result.stderr)
+    assert result.returncode == 0
+
+
+def test_kcidev_checkout_help(kcidev_config):
+    command = [
+        "poetry",
+        "run",
+        "kci-dev",
+        "--settings",
+        kcidev_config,
+        "checkout",
+        "--help",
+    ]
+    result = run(command, stdout=PIPE, stderr=PIPE, universal_newlines=True)
+    print("returncode: " + str(result.returncode))
+    print("#### stdout ####")
+    print(result.stdout)
+    print("#### stderr ####")
+    print(result.stderr)
+    assert result.returncode == 0
+
+
+def test_kcidev_results_tests(kcidev_config):
+    command = [
+        "poetry",
+        "run",
+        "kci-dev",
+        "--settings",
+        kcidev_config,
         "--instance",
         "staging",
         "maestro-results",
@@ -112,11 +159,13 @@ def test_create_repo():
     r.index.commit("test")
 
 
-def test_kcidev_commit():
+def test_kcidev_commit(kcidev_config):
     command = [
         "poetry",
         "run",
         "kci-dev",
+        "--settings",
+        kcidev_config,
         "--instance",
         "staging",
         "commit",
@@ -149,8 +198,3 @@ def test_main():
 def test_clean():
     # clean enviroment
     shutil.rmtree("my-new-repo/")
-
-    if os.path.isfile(".kci-dev.toml"):
-        os.remove(".kci-dev.toml")
-    else:
-        print("File does not exist")


### PR DESCRIPTION
…older path

add config subcommand to the subcommand that don't need a config present. config subcommand is needed for creating a config file. also config subcommand now support current folder path. The function add_config that create the config file is now tested under pytest with tmpdir_factory fixture