### PR TITLE
fix(docs,bisect,checkout): Improve debug output on failures

### DIFF
--- a/docs/checkout.md
+++ b/docs/checkout.md
@@ -167,6 +167,7 @@ Together with --watch option, you can use --test option to wait for particular t
 - `pass` - return code 0 (test passed)
 - `fail` - return code 1 (test failed)
 - `error` - return code 2 (prior steps failed, such as compilation, test setup, etc, or infrastructure error)
+- `critical error` - return code 64 (kci-dev failed to execute command, crashed, etc)
 
 For example:
 ```sh

--- a/kcidev/subcommands/bisect.py
+++ b/kcidev/subcommands/bisect.py
@@ -168,10 +168,10 @@ def bisection_loop(state):
     ]
     # job_filter is array, so we need to add each element as a separate argument
     for job in state["job_filter"]:
-        cmd.append("--job_filter")
+        cmd.append("--job-filter")
         cmd.append(job)
     for platform in state["platform_filter"]:
-        cmd.append("--platform_filter")
+        cmd.append("--platform-filter")
         cmd.append(platform)
     result = kcidev_exec(cmd)
     try:
@@ -187,10 +187,16 @@ def bisection_loop(state):
     elif testret == 2:
         # TBD: Retry failed test to make sure it is not a flaky test
         bisect_result = "skip"
-    else:
-        kci_err("Maestro failed to execute the test")
+    elif testret == 3:
+        kci_err(f"Maestro failed to execute the test.")
         # Internal maestro error, retry procesure
         return None
+    else:
+        kci_err(
+            f"Unknown or critical return code from kci-dev: {testret}. Try to run last command manually and inspect the output:"
+        )
+        kci_err(f"{' '.join(cmd)}")
+        sys.exit(1)
     cmd = ["git", "bisect", bisect_result]
     commitid = git_exec_getcommit(cmd)
     if not commitid:

--- a/kcidev/subcommands/checkout.py
+++ b/kcidev/subcommands/checkout.py
@@ -36,7 +36,7 @@ def send_checkout_full(baseurl, token, **kwargs):
         response = requests.post(url, headers=headers, data=jdata, timeout=30)
     except requests.exceptions.RequestException as e:
         kci_err(f"API connection error: {e}")
-        return
+        return None
 
     if response.status_code != 200:
         maestro_api_error(response)
@@ -267,6 +267,10 @@ def checkout(
         platform_filter=platform_filter,
         watch=watch,
     )
+    if not resp:
+        kci_err("Failed to trigger checkout")
+        sys.exit(64)
+
     if resp and "message" in resp:
         click.secho(resp["message"], fg="green")
 


### PR DESCRIPTION
Sometimes when we issue invalid command during bisect, we need to be less obscure why did it happen and how to reproduce. Also use a bit more correct job-filter/platform-filter commands, even underscore works too.
Example:
```
ci-dev bisect --workdir kcidev-src/ --giturl https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git --branch linux-5.15.y --job-filter kbuild-gcc-12-x86 --job-filter baseline-x86-intel --test baseline-x86-intel --platform-filter acer-chromebox-cxi4-puff --good 3a5928702e7120f83f703fd566082bfb59f1a57e --bad 584a40a22cb9bf5a03135869f11c3106b6200453
Loaded state file
giturl: https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git
branch: linux-5.15.y
good: 3a5928702e7120f83f703fd566082bfb59f1a57e
bad: 584a40a22cb9bf5a03135869f11c3106b6200453
retryfail: 2
history: [{'62356668d855deb075a93fdf9f26888c4f80b7d6': 'good'}, {'fdb6429ae356cf2bb4f8a34c3ae7f9f48af78ce7': 'good'}, {'eb54979471aa97182e05aa4e91a1072fa862bf62': 'good'}, {'f30ea678a21e73eb9aaa64f9d11558a9bb85a97f': 'good'}, {'e31942147bf5c7fe532f4703e6229c3ffd075dfe': 'good'}, {'7db54f3ba8cf45a8a3b97472a6f3703293195706': 'good'}]
job_filter: ['kbuild-gcc-12-x86', 'baseline-x86-intel']
platform_filter: ['acer-chromebox-cxi4-puff']
test: baseline-x86-intel
workdir: kcidev-src/
bisect_init: True
next_commit: 83948838e1c7a90015834d62932cec37d04941bf
Pulling repository
Bisection loop
Testing commit: 83948838e1c7a90015834d62932cec37d04941bf
Executing kci-dev command:  ['kci-dev', 'checkout', '--giturl', 'https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git', '--branch', 'linux-5.15.y', '--test', 'baseline-x86-intel', '--commit', '83948838e1c7a90015834d62932cec37d04941bf', '--watch', '--job-filter', 'kbuild-gcc-12-x86', '--job-filter', 'baseline-x86-intel', '--platform-filter', 'acer-chromebox-cxi4-puff']
maestro api endpoint: https://staging.kernelci.org:9100/api/checkout
Unknown or critical return code from kci-dev: 64. Try to run last command manually and inspect the output:
kci-dev checkout --giturl https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux-stable-rc.git --branch linux-5.15.y --test baseline-x86-intel --commit 83948838e1c7a90015834d62932cec37d04941bf --watch --job-filter kbuild-gcc-12-x86 --job-filter baseline-x86-intel --platform-filter acer-chromebox-cxi4-puff

```
