### PR TITLE
checkout: print treeid and checkout nodeid by default

### DIFF
--- a/kcidev/subcommands/checkout.py
+++ b/kcidev/subcommands/checkout.py
@@ -147,6 +147,16 @@ def checkout(
     if resp and "message" in resp:
         click.secho(resp["message"], fg="green")
 
+    if resp and "node" in resp:
+        node = resp.get("node")
+        treeid = node.get("treeid")
+        checkout_nodeid = node.get("id")
+
+        if treeid:
+            click.secho(f"treeid: {treeid}", fg="green")
+        if checkout_nodeid:
+            click.secho(f"checkout_nodeid: {checkout_nodeid}", fg="green")
+
     if watch and isinstance(resp, dict):
         node = resp.get("node")
         treeid = node.get("treeid")


### PR DESCRIPTION
Print treeid and checkout nodeid by default to help scripts calling kci-dev parse the checkout response. This allows retrieving the build nodeid for a given checkout nodeid.