### PR TITLE
Add kci-dev results test subcommand

### DIFF
--- a/docs/results.md
+++ b/docs/results.md
@@ -58,6 +58,16 @@ Example:
 kci-dev results tests --giturl 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git' --branch master --commit  d1486dca38afd08ca279ae94eb3a397f10737824
 ```
 
+### test
+
+Obtains a single test result.
+
+Example:
+
+```sh
+kci-dev results test --id 'maestro:67d3e293f378f0c5986d3309' --download-logs --json
+```
+
 ## Common parameters
 
 ### --origin

--- a/kcidev/libs/dashboard.py
+++ b/kcidev/libs/dashboard.py
@@ -91,6 +91,11 @@ def dashboard_fetch_tests(origin, giturl, branch, commit, arch):
     return dashboard_api_fetch(endpoint, params)
 
 
+def dashboard_fetch_test(test_id):
+    endpoint = f"test/{test_id}"
+    return dashboard_api_fetch(endpoint, {})
+
+
 def dashboard_fetch_tree_list(origin):
     params = {
         "origin": origin,

--- a/kcidev/libs/files.py
+++ b/kcidev/libs/files.py
@@ -1,0 +1,25 @@
+import gzip
+import os
+import re
+
+import requests
+from libs.common import kci_err
+
+INVALID_FILE_CHARS = re.compile(r'[\\/:"*?<>|]+')
+
+
+def to_valid_filename(filename):
+    return INVALID_FILE_CHARS.sub("", filename)
+
+
+def download_logs_to_file(log_url, log_file):
+    try:
+        log_gz = requests.get(log_url)
+        log = gzip.decompress(log_gz.content)
+        log_file = to_valid_filename(log_file)
+        with open(log_file, mode="wb") as file:
+            file.write(log)
+        log_path = "file://" + os.path.join(os.getcwd(), log_file)
+        return log_path
+    except:
+        kci_err(f"Failed to fetch log {log_url}.")

--- a/kcidev/subcommands/results/__init__.py
+++ b/kcidev/subcommands/results/__init__.py
@@ -7,12 +7,14 @@ from libs.dashboard import (
     dashboard_fetch_boots,
     dashboard_fetch_builds,
     dashboard_fetch_summary,
+    dashboard_fetch_test,
     dashboard_fetch_tests,
 )
 from libs.git_repo import set_giturl_branch_commit
 from subcommands.results.parser import (
     cmd_builds,
     cmd_list_trees,
+    cmd_single_test,
     cmd_summary,
     cmd_tests,
 )
@@ -63,7 +65,7 @@ def common_options(func):
     return wrapper
 
 
-def build_and_test_options(func):
+def builds_and_tests_options(func):
     @click.option(
         "--download-logs",
         is_flag=True,
@@ -82,6 +84,25 @@ def build_and_test_options(func):
     )
     @click.option(
         "--count", is_flag=True, help="Display the number of matching results"
+    )
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+def single_build_and_test_options(func):
+    @click.option(
+        "--id",
+        "op_id",
+        required=True,
+        help="Pass an id filter to get specific results",
+    )
+    @click.option(
+        "--download-logs",
+        is_flag=True,
+        help="Select desired results action",
     )
     @wraps(func)
     def wrapper(*args, **kwargs):
@@ -121,7 +142,7 @@ def trees(origin, use_json):
 
 @results.command()
 @common_options
-@build_and_test_options
+@builds_and_tests_options
 def builds(
     origin,
     git_folder,
@@ -146,7 +167,7 @@ def builds(
 
 @results.command()
 @common_options
-@build_and_test_options
+@builds_and_tests_options
 def boots(
     origin,
     git_folder,
@@ -171,7 +192,7 @@ def boots(
 
 @results.command()
 @common_options
-@build_and_test_options
+@builds_and_tests_options
 def tests(
     origin,
     git_folder,
@@ -192,6 +213,14 @@ def tests(
     )
     data = dashboard_fetch_tests(origin, giturl, branch, commit, arch)
     cmd_tests(data["tests"], commit, download_logs, status, filter, count, use_json)
+
+
+@results.command()
+@single_build_and_test_options
+@results_display_options
+def test(op_id, download_logs, use_json):
+    data = dashboard_fetch_test(op_id)
+    cmd_single_test(data, download_logs, use_json)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The command accepts --id <test_id>, along with --json and --download-logs.
We also move the download logs function to libs/files.py and create a function that verifies that creates portable filenames.

fixes #136