### PR TITLE
Format error as json when using --json

### DIFF
--- a/kcidev/libs/dashboard.py
+++ b/kcidev/libs/dashboard.py
@@ -7,7 +7,7 @@ from kcidev.libs.common import *
 DASHBOARD_API = "https://dashboard.kernelci.org/api/"
 
 
-def dashboard_api_fetch(endpoint, params, max_retries=3):
+def dashboard_api_fetch(endpoint, params, use_json, max_retries=3):
     base_url = urllib.parse.urljoin(DASHBOARD_API, endpoint)
     url = "{}?{}".format(base_url, urllib.parse.urlencode(params))
     retries = 0
@@ -31,7 +31,10 @@ def dashboard_api_fetch(endpoint, params, max_retries=3):
 
             data = r.json()
             if "error" in data:
-                kci_msg("json error: " + str(data["error"]))
+                if use_json:
+                    kci_msg(data)
+                else:
+                    kci_msg("json error: " + str(data["error"]))
                 raise click.Abort()
             return data
 
@@ -43,7 +46,7 @@ def dashboard_api_fetch(endpoint, params, max_retries=3):
     raise click.Abort()
 
 
-def dashboard_fetch_summary(origin, giturl, branch, commit, arch):
+def dashboard_fetch_summary(origin, giturl, branch, commit, arch, use_json):
     endpoint = f"tree/{commit}/summary"
     params = {
         "origin": origin,
@@ -52,10 +55,10 @@ def dashboard_fetch_summary(origin, giturl, branch, commit, arch):
     }
     if arch is not None:
         params["filter_architecture"] = arch
-    return dashboard_api_fetch(endpoint, params)
+    return dashboard_api_fetch(endpoint, params, use_json)
 
 
-def dashboard_fetch_builds(origin, giturl, branch, commit, arch):
+def dashboard_fetch_builds(origin, giturl, branch, commit, arch, use_json):
     endpoint = f"tree/{commit}/builds"
     params = {
         "origin": origin,
@@ -64,10 +67,10 @@ def dashboard_fetch_builds(origin, giturl, branch, commit, arch):
     }
     if arch is not None:
         params["filter_architecture"] = arch
-    return dashboard_api_fetch(endpoint, params)
+    return dashboard_api_fetch(endpoint, params, use_json)
 
 
-def dashboard_fetch_boots(origin, giturl, branch, commit, arch):
+def dashboard_fetch_boots(origin, giturl, branch, commit, arch, use_json):
     endpoint = f"tree/{commit}/boots"
     params = {
         "origin": origin,
@@ -76,10 +79,10 @@ def dashboard_fetch_boots(origin, giturl, branch, commit, arch):
     }
     if arch is not None:
         params["filter_architecture"] = arch
-    return dashboard_api_fetch(endpoint, params)
+    return dashboard_api_fetch(endpoint, params, use_json)
 
 
-def dashboard_fetch_tests(origin, giturl, branch, commit, arch):
+def dashboard_fetch_tests(origin, giturl, branch, commit, arch, use_json):
     endpoint = f"tree/{commit}/tests"
     params = {
         "origin": origin,
@@ -88,16 +91,16 @@ def dashboard_fetch_tests(origin, giturl, branch, commit, arch):
     }
     if arch is not None:
         params["filter_architecture"] = arch
-    return dashboard_api_fetch(endpoint, params)
+    return dashboard_api_fetch(endpoint, params, use_json)
 
 
-def dashboard_fetch_test(test_id):
+def dashboard_fetch_test(test_id, use_json):
     endpoint = f"test/{test_id}"
-    return dashboard_api_fetch(endpoint, {})
+    return dashboard_api_fetch(endpoint, {}, use_json)
 
 
-def dashboard_fetch_tree_list(origin):
+def dashboard_fetch_tree_list(origin, use_json):
     params = {
         "origin": origin,
     }
-    return dashboard_api_fetch("tree-fast", params)
+    return dashboard_api_fetch("tree-fast", params, use_json)

--- a/kcidev/libs/git_repo.py
+++ b/kcidev/libs/git_repo.py
@@ -90,7 +90,7 @@ def get_folder_repository(git_folder, branch):
 
 
 def get_latest_commit(origin, giturl, branch):
-    trees = dashboard_fetch_tree_list(origin)
+    trees = dashboard_fetch_tree_list(origin, False)
     for t in trees:
         if t["git_repository_url"] == giturl and t["git_repository_branch"] == branch:
             return t["git_commit_hash"]

--- a/kcidev/subcommands/results/__init__.py
+++ b/kcidev/subcommands/results/__init__.py
@@ -124,7 +124,7 @@ def summary(origin, git_folder, giturl, branch, commit, latest, arch, use_json):
     giturl, branch, commit = set_giturl_branch_commit(
         origin, giturl, branch, commit, latest, git_folder
     )
-    data = dashboard_fetch_summary(origin, giturl, branch, commit, arch)
+    data = dashboard_fetch_summary(origin, giturl, branch, commit, arch, use_json)
     cmd_summary(data, use_json)
 
 
@@ -161,7 +161,7 @@ def builds(
     giturl, branch, commit = set_giturl_branch_commit(
         origin, giturl, branch, commit, latest, git_folder
     )
-    data = dashboard_fetch_builds(origin, giturl, branch, commit, arch)
+    data = dashboard_fetch_builds(origin, giturl, branch, commit, arch, use_json)
     cmd_builds(data, commit, download_logs, status, count, use_json)
 
 
@@ -186,7 +186,7 @@ def boots(
     giturl, branch, commit = set_giturl_branch_commit(
         origin, giturl, branch, commit, latest, git_folder
     )
-    data = dashboard_fetch_boots(origin, giturl, branch, commit, arch)
+    data = dashboard_fetch_boots(origin, giturl, branch, commit, arch, use_json)
     cmd_tests(data["boots"], commit, download_logs, status, filter, count, use_json)
 
 
@@ -211,7 +211,7 @@ def tests(
     giturl, branch, commit = set_giturl_branch_commit(
         origin, giturl, branch, commit, latest, git_folder
     )
-    data = dashboard_fetch_tests(origin, giturl, branch, commit, arch)
+    data = dashboard_fetch_tests(origin, giturl, branch, commit, arch, use_json)
     cmd_tests(data["tests"], commit, download_logs, status, filter, count, use_json)
 
 
@@ -219,7 +219,7 @@ def tests(
 @single_build_and_test_options
 @results_display_options
 def test(op_id, download_logs, use_json):
-    data = dashboard_fetch_test(op_id)
+    data = dashboard_fetch_test(op_id, use_json)
     cmd_single_test(data, download_logs, use_json)
 
 


### PR DESCRIPTION
Only errors written to stdin use the --json flag.

fixes #141