### PR TITLE
Fix: Turn relative imports to absolute imports

### DIFF
--- a/kcidev/libs/files.py
+++ b/kcidev/libs/files.py
@@ -3,7 +3,8 @@ import os
 import re
 
 import requests
-from libs.common import kci_err
+
+from kcidev.libs.common import kci_err
 
 INVALID_FILE_CHARS = re.compile(r'[\\/:"*?<>|]+')
 

--- a/kcidev/libs/git_repo.py
+++ b/kcidev/libs/git_repo.py
@@ -3,9 +3,8 @@ import os
 import subprocess
 import urllib
 
-from libs.dashboard import dashboard_fetch_tree_list
-
 from kcidev.libs.common import *
+from kcidev.libs.dashboard import dashboard_fetch_tree_list
 
 
 def repository_url_cleaner(url):

--- a/kcidev/subcommands/results/__init__.py
+++ b/kcidev/subcommands/results/__init__.py
@@ -3,7 +3,8 @@
 from functools import wraps
 
 import click
-from libs.dashboard import (
+
+from kcidev.libs.dashboard import (
     dashboard_fetch_boots,
     dashboard_fetch_build,
     dashboard_fetch_builds,
@@ -11,15 +12,15 @@ from libs.dashboard import (
     dashboard_fetch_test,
     dashboard_fetch_tests,
 )
-from libs.git_repo import set_giturl_branch_commit
-from subcommands.results.hardware import hardware
-from subcommands.results.options import (
+from kcidev.libs.git_repo import set_giturl_branch_commit
+from kcidev.subcommands.results.hardware import hardware
+from kcidev.subcommands.results.options import (
     builds_and_tests_options,
     common_options,
     results_display_options,
     single_build_and_test_options,
 )
-from subcommands.results.parser import (
+from kcidev.subcommands.results.parser import (
     cmd_builds,
     cmd_list_trees,
     cmd_single_build,

--- a/kcidev/subcommands/results/hardware.py
+++ b/kcidev/subcommands/results/hardware.py
@@ -1,10 +1,11 @@
 import click
-from libs.dashboard import (
+
+from kcidev.libs.dashboard import (
     dashboard_fetch_hardware_list,
     dashboard_fetch_hardware_summary,
 )
-from subcommands.results.options import results_display_options
-from subcommands.results.parser import cmd_hardware_list, cmd_summary
+from kcidev.subcommands.results.options import results_display_options
+from kcidev.subcommands.results.parser import cmd_hardware_list, cmd_summary
 
 
 @click.group(chain=True, help="Get hardware related information from the dashboard")

--- a/kcidev/subcommands/results/parser.py
+++ b/kcidev/subcommands/results/parser.py
@@ -3,10 +3,10 @@ import json
 
 import requests
 import yaml
-from libs.dashboard import dashboard_fetch_tree_list
-from libs.files import download_logs_to_file
 
 from kcidev.libs.common import *
+from kcidev.libs.dashboard import dashboard_fetch_tree_list
+from kcidev.libs.files import download_logs_to_file
 
 
 def print_summary(type, n_pass, n_fail, n_inconclusive):


### PR DESCRIPTION
Some modules were considering relative imports to other parts of the client. This works on a local enviroments but fails when installing the client using pip or packaging the code