### PR TITLE
results: Fix dashboard_fetch_tree_list() invocation

### DIFF
--- a/kcidev/subcommands/results/parser.py
+++ b/kcidev/subcommands/results/parser.py
@@ -125,7 +125,7 @@ def get_command_summary(command_data):
 
 
 def cmd_list_trees(origin, use_json):
-    trees = dashboard_fetch_tree_list(origin)
+    trees = dashboard_fetch_tree_list(origin, use_json)
     if use_json:
         kci_msg(json.dumps(list(map(lambda t: create_tree_json(t), trees))))
         return


### PR DESCRIPTION
Commit d45d0db ("Format error as json when using --json") added a new positional argument called **use_json** to the `dashboard_api_fetch()` method while fixing something else.

As part of the change, most of the callers of the `dashboard_api_fetch()`, such as the `dashboard_fetch_tree_list()` helper, were updated to correctly pass the new argument around.

However, the `cmd_list_trees()` was not updated to pass the new argument correctly to the aforementioned helper function, which it uses internally.

As such, when using kci-dev with the "results trees" subcommand, this results in a `TypeError` as follows:

```
TypeError: dashboard_fetch_tree_list() missing 1 required positional argument: 'use_json'
```

Thus, add the missing argument when invoking `dashboard_fetch_tree_list()` to fix the subcommand invocation error.