### PR TITLE
docs(contributions): add suggested commit format

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,3 +33,28 @@ Just append `poe check` to your pre-commit file
 ```shell
 echo "poe check" >> .git/hooks/pre-commit
 ```
+
+### **Suggested commit format**
+
+We recommend following the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#specification), which has the following format:
+
+```shell
+<type>[optional scope]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+Types usually are:
+
+1. **fix**: meaning the commit patches a bug in the codebase.
+2. **feat**: the commit introduces a new feature to the codebase.
+3. **feat!** or **fix!**: the commit introduces a breaking API change.
+4. Other types are allowed, for example: **build**, **cli**, **test**, **docs**.
+
+When a commit introduces a breaking change in the API it is recommended to add a **BREAKING CHANGE:** footer.
+
+To provide contextual information an scope may be provided alongside the type. This needs to be contained within parenthesis, for example, `feat(parser): add ability to parse arrays`.
+
+You can find more details on the Conventional Commits specification site.


### PR DESCRIPTION
The contributions guidelines are updated to include a suggested format based on the Conventional Commits specification.