### PR TITLE
Hardware subcommands

### DIFF
--- a/docs/results.md
+++ b/docs/results.md
@@ -28,7 +28,7 @@ Example:
 kci-dev results summary --giturl 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git' --branch master --commit  d1486dca38afd08ca279ae94eb3a397f10737824
 ```
 
-### builds
+### <a id="result-builds"></a>builds
 
 List builds results.
 
@@ -111,6 +111,17 @@ Example:
 
 ```sh
 kci-dev results hardware boots --name mediatek,mt8195 --origin maestro --json
+```
+
+#### builds
+
+List build results for a hardware with `name` list for the last seven days.
+It supports the same options as [results builds](#result-builds).
+
+Example:
+
+```sh
+kci-dev results hardware builds --name mediatek,mt8195 --origin maestro --json
 ```
 
 ## Common parameters

--- a/docs/results.md
+++ b/docs/results.md
@@ -48,7 +48,7 @@ Example:
 kci-dev results boots --giturl 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git' --branch master --latest
 ```
 
-### tests
+### <a id="result-tests"></a>tests
 
 List test results.
 
@@ -122,6 +122,17 @@ Example:
 
 ```sh
 kci-dev results hardware builds --name mediatek,mt8195 --origin maestro --json
+```
+
+#### tests
+
+List test results for a hardware with `name` list for the last seven days.
+It supports the same options as [results tests](#result-tests).
+
+Example:
+
+```sh
+kci-dev results hardware tests --name mediatek,mt8195 --origin maestro --json
 ```
 
 ## Common parameters

--- a/docs/results.md
+++ b/docs/results.md
@@ -38,7 +38,7 @@ Example:
 kci-dev results builds --giturl 'https://git.kernel.org/pub/scm/linux/kernel/git/next/linux-next.git' --branch master --commit  d1486dca38afd08ca279ae94eb3a397f10737824
 ```
 
-### boots
+### <a id="result-boots"></a>boots
 
 List boot results.
 
@@ -100,6 +100,17 @@ Example:
 
 ```sh
 kci-dev results hardware summary --name mediatek,mt8195 --origin maestro --json
+```
+
+#### boots
+
+List boot results for a hardware with `name` list for the last seven days.
+It supports the same options as [results boots](#result-boots).
+
+Example:
+
+```sh
+kci-dev results hardware boots --name mediatek,mt8195 --origin maestro --json
 ```
 
 ## Common parameters

--- a/kcidev/libs/dashboard.py
+++ b/kcidev/libs/dashboard.py
@@ -139,8 +139,7 @@ def dashboard_fetch_hardware_list(origin, use_json):
     return dashboard_api_fetch("hardware/", params, use_json)
 
 
-def dashboard_fetch_hardware_summary(name, origin, use_json):
-    # TODO: add extra filters: Commits, date, filter, origin
+def _create_hardware_request_body(origin):
     now = datetime.today()
     last_week = now - timedelta(days=7)
     body = {
@@ -150,6 +149,19 @@ def dashboard_fetch_hardware_summary(name, origin, use_json):
         "selectedCommits": {},
         "filter": {},
     }
+    return body
+
+
+def dashboard_fetch_hardware_summary(name, origin, use_json):
+    # TODO: add extra filters: Commits, date, filter, origin
+    body = _create_hardware_request_body(origin)
     return dashboard_api_post(
         f"hardware/{urllib.parse.quote_plus(name)}/summary", {}, use_json, body
+    )
+
+
+def dashboard_fetch_hardware_boots(name, origin, use_json):
+    body = _create_hardware_request_body(origin)
+    return dashboard_api_post(
+        f"hardware/{urllib.parse.quote_plus(name)}/boots", {}, use_json, body
     )

--- a/kcidev/libs/dashboard.py
+++ b/kcidev/libs/dashboard.py
@@ -172,3 +172,10 @@ def dashboard_fetch_hardware_builds(name, origin, use_json):
     return dashboard_api_post(
         f"hardware/{urllib.parse.quote_plus(name)}/builds", {}, use_json, body
     )
+
+
+def dashboard_fetch_hardware_tests(name, origin, use_json):
+    body = _create_hardware_request_body(origin)
+    return dashboard_api_post(
+        f"hardware/{urllib.parse.quote_plus(name)}/tests", {}, use_json, body
+    )

--- a/kcidev/libs/dashboard.py
+++ b/kcidev/libs/dashboard.py
@@ -165,3 +165,10 @@ def dashboard_fetch_hardware_boots(name, origin, use_json):
     return dashboard_api_post(
         f"hardware/{urllib.parse.quote_plus(name)}/boots", {}, use_json, body
     )
+
+
+def dashboard_fetch_hardware_builds(name, origin, use_json):
+    body = _create_hardware_request_body(origin)
+    return dashboard_api_post(
+        f"hardware/{urllib.parse.quote_plus(name)}/builds", {}, use_json, body
+    )

--- a/kcidev/subcommands/results/hardware.py
+++ b/kcidev/subcommands/results/hardware.py
@@ -7,6 +7,7 @@ from kcidev.libs.dashboard import (
     dashboard_fetch_hardware_builds,
     dashboard_fetch_hardware_list,
     dashboard_fetch_hardware_summary,
+    dashboard_fetch_hardware_tests,
 )
 from kcidev.subcommands.results.options import (
     builds_and_tests_options,
@@ -68,3 +69,12 @@ def boots(name, origin, use_json, download_logs, status, filter, count):
 def builds(name, origin, use_json, download_logs, status, filter, count):
     data = dashboard_fetch_hardware_builds(name, origin, use_json)
     cmd_builds(data, name, download_logs, status, count, use_json)
+
+
+@hardware.command()
+@hardware_common_opt
+@results_display_options
+@builds_and_tests_options
+def tests(name, origin, use_json, download_logs, status, filter, count):
+    data = dashboard_fetch_hardware_tests(name, origin, use_json)
+    cmd_tests(data["tests"], name, download_logs, status, filter, count, use_json)

--- a/kcidev/subcommands/results/hardware.py
+++ b/kcidev/subcommands/results/hardware.py
@@ -4,6 +4,7 @@ import click
 
 from kcidev.libs.dashboard import (
     dashboard_fetch_hardware_boots,
+    dashboard_fetch_hardware_builds,
     dashboard_fetch_hardware_list,
     dashboard_fetch_hardware_summary,
 )
@@ -11,7 +12,12 @@ from kcidev.subcommands.results.options import (
     builds_and_tests_options,
     results_display_options,
 )
-from kcidev.subcommands.results.parser import cmd_hardware_list, cmd_summary, cmd_tests, cmd_builds
+from kcidev.subcommands.results.parser import (
+    cmd_builds,
+    cmd_hardware_list,
+    cmd_summary,
+    cmd_tests,
+)
 
 
 def hardware_common_opt(func):
@@ -54,3 +60,11 @@ def boots(name, origin, use_json, download_logs, status, filter, count):
     data = dashboard_fetch_hardware_boots(name, origin, use_json)
     cmd_tests(data["boots"], name, download_logs, status, filter, count, use_json)
 
+
+@hardware.command()
+@hardware_common_opt
+@results_display_options
+@builds_and_tests_options
+def builds(name, origin, use_json, download_logs, status, filter, count):
+    data = dashboard_fetch_hardware_builds(name, origin, use_json)
+    cmd_builds(data, name, download_logs, status, count, use_json)

--- a/kcidev/subcommands/results/hardware.py
+++ b/kcidev/subcommands/results/hardware.py
@@ -1,11 +1,27 @@
+from functools import wraps
+
 import click
 
 from kcidev.libs.dashboard import (
+    dashboard_fetch_hardware_boots,
     dashboard_fetch_hardware_list,
     dashboard_fetch_hardware_summary,
 )
-from kcidev.subcommands.results.options import results_display_options
-from kcidev.subcommands.results.parser import cmd_hardware_list, cmd_summary
+from kcidev.subcommands.results.options import (
+    builds_and_tests_options,
+    results_display_options,
+)
+from kcidev.subcommands.results.parser import cmd_hardware_list, cmd_summary, cmd_tests, cmd_builds
+
+
+def hardware_common_opt(func):
+    @click.option("--name", required=True, help="Name of the hardware")
+    @click.option("--origin", default="maestro", help="Select KCIDB origin")
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        return func(*args, **kwargs)
+
+    return wrapper
 
 
 @click.group(chain=True, help="Get hardware related information from the dashboard")
@@ -23,9 +39,18 @@ def list(origin, use_json):
 
 
 @hardware.command()
-@click.option("--name", required=True, help="Name of the hardware")
-@click.option("--origin", default="maestro", help="Select KCIDB origin")
+@hardware_common_opt
 @results_display_options
 def summary(name, origin, use_json):
     data = dashboard_fetch_hardware_summary(name, origin, use_json)
     cmd_summary(data, use_json)
+
+
+@hardware.command()
+@hardware_common_opt
+@results_display_options
+@builds_and_tests_options
+def boots(name, origin, use_json, download_logs, status, filter, count):
+    data = dashboard_fetch_hardware_boots(name, origin, use_json)
+    cmd_tests(data["boots"], name, download_logs, status, filter, count, use_json)
+

--- a/kcidev/subcommands/results/parser.py
+++ b/kcidev/subcommands/results/parser.py
@@ -242,7 +242,7 @@ def filter_out_by_test(test, filter_data):
     return True
 
 
-def cmd_tests(data, commit, download_logs, status_filter, filter, count, use_json):
+def cmd_tests(data, id, download_logs, status_filter, filter, count, use_json):
     filter_data = yaml.safe_load(filter) if filter else None
     filtered_tests = 0
     tests = []
@@ -263,7 +263,7 @@ def cmd_tests(data, commit, download_logs, status_filter, filter, count, use_jso
                 if "environment_misc" in test
                 else "(Unknown platform)"
             )
-            log_file = f"{platform}__{test['path']}__{test['config']}-{test['architecture']}-{test['compiler']}-{commit}.log"
+            log_file = f"{platform}__{test['path']}__{test['config']}-{test['architecture']}-{test['compiler']}-{id}.log"
             log_path = download_logs_to_file(test["log_url"], log_file)
         if count:
             filtered_tests += 1


### PR DESCRIPTION
Includes boots, builds and tests subcommands.
Below an example for each of them:

- Boots:

`kci-dev results hardware boots --name mediatek,mt8195 --origin maestro --status pass`

- Builds:

`kci-dev results hardware builds --compatibles mediatek,mt8195 --origin maestro `

- Tests:

`kci-dev results hardware tests --name amlogic,meson-gxl --origin maestro --status fail`