### PR TITLE
feat(results): Add boot subcommand

### DIFF
--- a/docs/results.md
+++ b/docs/results.md
@@ -68,6 +68,16 @@ Example:
 kci-dev results test --id 'maestro:67d3e293f378f0c5986d3309' --download-logs --json
 ```
 
+### boot
+
+Obtains a single boot result.
+
+Example:
+
+```sh
+kci-dev results boot --id 'maestro:67ffde3a69241b2ece0ccaa6' --download-logs --json
+```
+
 ### build
 
 Displays all the information from a single build.

--- a/kcidev/subcommands/results/__init__.py
+++ b/kcidev/subcommands/results/__init__.py
@@ -153,5 +153,13 @@ def build(op_id, download_logs, use_json):
     cmd_single_build(data, download_logs, use_json)
 
 
+@results.command()
+@single_build_and_test_options
+@results_display_options
+def boot(op_id, download_logs, use_json):
+    data = dashboard_fetch_test(op_id, use_json)
+    cmd_single_test(data, download_logs, use_json)
+
+
 if __name__ == "__main__":
     main_kcidev()


### PR DESCRIPTION
Add a `boot` subcommand to `results`.

Now we can both obtain all boots per tree and a single boot by id, just like with tests and builds.

The subcommand supports the same arguments as `results test`and `results build`. 
An example of usage would be:
```
kci-dev results boot --id 'maestro:67ffde3a69241b2ece0ccaa6' 
```