### PR TITLE
Allow wildcards in filter file

### DIFF
--- a/docs/results.md
+++ b/docs/results.md
@@ -201,6 +201,7 @@ kci-dev results builds --giturl 'https://git.kernel.org/pub/scm/linux/kernel/git
 ## --filter
 
 Pass a YAML filter file to customize results. Only supports hardware and test name filtering at the moment.
+You can use wildcards (`*`) in both `hardware` and `test`.
 See filter yaml example below:
 (available for subcommands `boots` and `tests`)
 
@@ -212,6 +213,7 @@ hardware:
 test:
   - kselftest.dt
   - kselftest.iommu
+  - kunit.*
 ```
 
 Example:

--- a/kcidev/subcommands/results/parser.py
+++ b/kcidev/subcommands/results/parser.py
@@ -225,13 +225,13 @@ def filter_out_by_hardware(test, filter_data):
     if "hardware" not in filter_data:
         return False
 
-    hardware_list = filter_data["hardware"]
-    if test["environment_misc"]["platform"] in hardware_list:
+    hardware_list_re = re.compile(filter_data["hardware"])
+    if hardware_list_re.match(test["environment_misc"]["platform"]):
         return False
 
     if test["environment_compatible"]:
         for compatible in test["environment_compatible"]:
-            if compatible in hardware_list:
+            if hardware_list_re.match(compatible):
                 return False
 
     return True
@@ -246,17 +246,19 @@ def filter_out_by_test(test, filter_data):
     return True
 
 
+def filter_array2regex(filter_array):
+    return f"^({'|'.join(filter_array)})$".replace(".", r"\.").replace("*", ".*")
+
+
 def parse_filter_file(filter):
     filter_data = yaml.safe_load(filter) if filter else None
     if filter_data is None:
         return None
     parsed_filter = {}
     if "hardware" in filter_data:
-        parsed_filter["hardware"] = filter_data["hardware"]
+        parsed_filter["hardware"] = filter_array2regex(filter_data["hardware"])
     if "test" in filter_data:
-        parsed_filter["test"] = rf"^({'|'.join(filter_data.get('test', []))})$".replace(
-            ".", r"\."
-        ).replace("*", ".*")
+        parsed_filter["test"] = filter_array2regex(filter_data["test"])
     return parsed_filter
 
 


### PR DESCRIPTION
The `--filter` option allows passing a file that will work as a filter for picking results for a set of devices and tests. The filters are strict in the sense that the test path must match the filter exactly to be included in the results.

This PR allows referencing both hardware and tests using wildcards.
All of the follow would now be considered a valid reference to a test or set of tests: `kunit`, `kunit.*`, `kselftest.iommu.*`.

The new format would support a file like this:
```
hardware:
  - radxa,rock2-square
  - fsl,imx6q
  - dell-latitude-3445-7520c-skyrim
test:
  - kselftest.iommu.*
  - kselftest.dt
  - kunit.*
```
closes #163 