### PR TITLE
Add comprehensive help documentation to all kci-dev commands

### DIFF
--- a/kcidev/subcommands/checkout.py
+++ b/kcidev/subcommands/checkout.py
@@ -59,51 +59,87 @@ def retrieve_tot_commit(repourl, branch):
     return sha
 
 
-@click.command(help="Trigger a test for a specific tree/branch/commit")
+@click.command(
+    help="""Trigger test runs for a specific kernel tree/branch/commit.
+
+This command submits a kernel checkout request to KernelCI's pipeline system,
+which will build and test the specified kernel version. You can filter which
+jobs and platforms to run, and optionally watch the results in real-time.
+
+Either --commit or --tipoftree must be specified to identify which kernel
+version to test.
+
+\b
+Examples:
+  # Test a specific commit
+  kci-dev checkout --giturl https://git.kernel.org/torvalds/linux.git \\
+                   --branch master --commit abc123def456
+
+  # Test the latest commit on a branch
+  kci-dev checkout --giturl https://git.kernel.org/torvalds/linux.git \\
+                   --branch master --tipoftree
+
+  # Test with job and platform filters, and watch results
+  kci-dev checkout --giturl https://git.kernel.org/torvalds/linux.git \\
+                   --branch master --tipoftree \\
+                   --job-filter baseline --platform-filter qemu-x86 \\
+                   --watch
+
+  # Watch for a specific test result and return appropriate exit code
+  kci-dev checkout --giturl ... --branch ... --commit ... \\
+                   --job-filter baseline --watch --test baseline.login
+"""
+)
 @click.option(
     "--giturl",
-    help="Git URL to checkout",
+    help="Git repository URL containing the kernel source",
     required=True,
 )
 @click.option(
     "--branch",
-    help="Branch to checkout",
+    help="Git branch to checkout and test",
     required=True,
 )
 @click.option(
     "--commit",
-    help="Commit to checkout",
+    help="Specific commit SHA to checkout (40 characters)",
 )
 @click.option(
     "--tipoftree",
-    help="Checkout on latest commit on tree/branch",
+    help="Use the latest commit on the specified tree/branch",
     is_flag=True,
 )
 @click.option(
     "--watch",
     "-w",
-    help="Interactively watch for a tasks in job-filter",
+    help="Watch and display test results interactively as they complete",
     is_flag=True,
 )
 # job_filter is a list, might be one or more jobs
 @click.option(
     "--job-filter",
-    help="Job filter to trigger",
+    help="Filter tests by job name (e.g., baseline, ltp). Can be used multiple times",
     multiple=True,
 )
 @click.option(
     "--platform-filter",
-    help="Platform filter to trigger",
+    help="Filter tests by platform (e.g., qemu-x86, rpi4). Can be used multiple times",
     multiple=True,
 )
 @click.option(
     "--test",
-    help="Return code based on the test result",
+    help="Watch for specific test result and set exit code accordingly (requires --watch)",
 )
 @click.pass_context
 def checkout(
     ctx, giturl, branch, commit, job_filter, platform_filter, tipoftree, watch, test
 ):
+    # Check if no parameters provided - show help
+    if not any([giturl, branch, commit, job_filter, platform_filter, tipoftree, watch, test]):
+        ctx = click.get_current_context()
+        click.echo(ctx.get_help())
+        sys.exit(0)
+    
     cfg = ctx.obj.get("CFG")
     instance = ctx.obj.get("INSTANCE")
     url = cfg[instance]["pipeline"]

--- a/kcidev/subcommands/checkout.py
+++ b/kcidev/subcommands/checkout.py
@@ -135,11 +135,13 @@ def checkout(
     ctx, giturl, branch, commit, job_filter, platform_filter, tipoftree, watch, test
 ):
     # Check if no parameters provided - show help
-    if not any([giturl, branch, commit, job_filter, platform_filter, tipoftree, watch, test]):
+    if not any(
+        [giturl, branch, commit, job_filter, platform_filter, tipoftree, watch, test]
+    ):
         ctx = click.get_current_context()
         click.echo(ctx.get_help())
         sys.exit(0)
-    
+
     cfg = ctx.obj.get("CFG")
     instance = ctx.obj.get("INSTANCE")
     url = cfg[instance]["pipeline"]

--- a/kcidev/subcommands/commit.py
+++ b/kcidev/subcommands/commit.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import json
+import sys
 
 import click
 import requests
@@ -44,27 +45,75 @@ def send_build(url, patch, branch, treeurl, token):
     # click.secho(response.json(), fg="green")
 
 
-@click.command(help="Test commits from a local Kernel repository")
+@click.command(
+    help="""Test local commits from a kernel repository.
+
+This command allows you to test local kernel commits that haven't been pushed
+to a remote repository. It extracts the diff between your local branch and the
+origin branch, then submits it for testing in KernelCI.
+
+Note: This command is currently experimental and the API integration is not
+fully operational.
+
+\b
+Examples:
+  # Test local commits on top of mainline master
+  kci-dev commit --path /path/to/kernel --branch my-feature
+
+  # Test commits from a different upstream repository
+  kci-dev commit --repository next --branch my-feature --origin linux-next/master
+
+  # Test commits privately (results not published)
+  kci-dev commit --private --path /path/to/kernel
+"""
+)
 @click.option(
     "--repository",
     default="mainline",
-    help="define the kernel upstream repository where to test local changes",
+    help="Upstream kernel repository name (default: mainline)",
 )
-@click.option("--branch", default="master", help="define the repository branch")
-@click.option("--origin", default="master", help="define the origin repository branch")
+@click.option(
+    "--branch",
+    default="master",
+    help="Local branch name with your commits (default: master)",
+)
+@click.option(
+    "--origin",
+    default="master",
+    help="Origin branch to compare against (default: master)",
+)
 @click.option(
     "--private",
     default=False,
     is_flag=True,
-    help="define if the test results will be published",
+    help="Keep test results private (not published publicly)",
 )
 @click.option(
     "--path",
     default=".",
-    help="define the directory of the local tree with local changes",
+    help="Path to local kernel repository (default: current directory)",
 )
 @click.pass_context
 def commit(ctx, repository, branch, origin, private, path):
+    # Check if user provided no custom options (all defaults)
+    # Show help if running with all defaults and no explicit path
+    if (
+        repository == "mainline"
+        and branch == "master"
+        and origin == "master"
+        and not private
+        and path == "."
+        and not ctx.parent.params.get("help")
+    ):
+        # Check if running in a git repo
+        try:
+            Repo(".")
+        except:
+            # Not in a git repo, show help
+            ctx = click.get_current_context()
+            click.echo(ctx.get_help())
+            sys.exit(0)
+
     config = ctx.obj.get("CFG")
     instance = ctx.obj.get("INSTANCE")
     url = api_connection(config[instance]["pipeline"])

--- a/kcidev/subcommands/config.py
+++ b/kcidev/subcommands/config.py
@@ -76,11 +76,33 @@ def add_config(fpath):
         raise click.Abort()
 
 
-@click.command(help="Config tool for creating a config file")
+@click.command(
+    help="""Create a configuration file for kci-dev.
+
+This command helps you set up a configuration file by copying a template
+configuration to your specified location. The configuration file contains
+settings for connecting to KernelCI instances, including API URLs and tokens.
+
+The command will check for existing configuration files in standard locations
+and prevent overwriting them. If no file path is specified, it will create
+the config at ~/.config/kci-dev/kci-dev.toml.
+
+\b
+Examples:
+  # Create config at default location
+  kci-dev config
+
+  # Create config at custom location
+  kci-dev config --file-path ~/my-kci-config.toml
+
+  # Create config in current directory
+  kci-dev config --file-path ./kci-dev.toml
+"""
+)
 @click.option(
     "--file-path",
     default="~/.config/kci-dev/kci-dev.toml",
-    help="File path for creating a config file, if none is provided ~/config/kci-dev/kci-dev.toml is used",
+    help="Path where the config file will be created (default: ~/.config/kci-dev/kci-dev.toml)",
 )
 @click.pass_context
 def config(

--- a/kcidev/subcommands/maestro_results.py
+++ b/kcidev/subcommands/maestro_results.py
@@ -8,41 +8,54 @@ from kcidev.libs.common import *
 from kcidev.libs.maestro_common import *
 
 
-@click.command(help="Get results directly from KernelCI's Maestro")
+@click.command(
+    help="""Query test results from KernelCI's Maestro API.
+
+This command allows you to retrieve test results either by specific node ID
+or by fetching the latest nodes with pagination and filtering options.
+
+\b
+Examples:
+  kci-dev maestro-results --nodeid <NODE_ID>
+  kci-dev maestro-results --nodes --limit 10
+  kci-dev maestro-results --nodes --filter "status=fail"
+  kci-dev maestro-results --nodes --field name --field status
+"""
+)
 @click.option(
     "--nodeid",
     required=False,
-    help="select node_id",
+    help="Retrieve results for a specific node ID",
 )
 @click.option(
     "--nodes",
     is_flag=True,
     required=False,
-    help="Get last nodes results",
+    help="Retrieve the latest test node results",
 )
 @click.option(
     "--limit",
     default=50,
     required=False,
-    help="Pagination limit for nodes",
+    help="Maximum number of nodes to retrieve (default: 50)",
 )
 @click.option(
     "--offset",
     default=0,
     required=False,
-    help="Offset of the pagination",
+    help="Starting position for pagination (default: 0)",
 )
 @click.option(
     "--filter",
     required=False,
     multiple=True,
-    help="Filter nodes by conditions",
+    help="Filter nodes by conditions (e.g., 'status=fail', 'name=test_*'). Can be used multiple times",
 )
 @click.option(
     "--field",
     required=False,
     multiple=True,
-    help="Print only particular field(s) from node data",
+    help="Display only specific field(s) from node data (e.g., 'name', 'status'). Can be used multiple times",
 )
 @click.pass_context
 def maestro_results(ctx, nodeid, nodes, limit, offset, filter, field):
@@ -50,8 +63,9 @@ def maestro_results(ctx, nodeid, nodes, limit, offset, filter, field):
     instance = ctx.obj.get("INSTANCE")
     url = config[instance]["api"]
     if not nodeid and not nodes:
-        kci_err("--nodes or --nodes needs to be supplied")
-        sys.exit(-1)
+        ctx = click.get_current_context()
+        click.echo(ctx.get_help())
+        sys.exit(0)
     if nodeid:
         results = maestro_get_node(url, nodeid)
     if nodes:

--- a/kcidev/subcommands/patch.py
+++ b/kcidev/subcommands/patch.py
@@ -28,20 +28,44 @@ def send_build(url, patch, branch, treeurl, token):
     click.secho(response.json(), fg="green")
 
 
-@click.command(help="Test a patch or a mbox file")
+@click.command(
+    help="""Test a kernel patch or mbox file against a specific tree/branch.
+
+This command allows you to submit a patch file for testing in KernelCI. The
+patch will be applied on top of the specified repository and branch, then
+built and tested. Both standard patch files and mbox files (from git
+format-patch or email) are supported.
+
+\b
+Examples:
+  # Test a patch against mainline master
+  kci-dev patch --patch my-fix.patch
+
+  # Test a patch against a specific tree and branch
+  kci-dev patch --patch feature.patch --repository next --branch linux-next/master
+
+  # Test a patch privately (results not published)
+  kci-dev patch --patch bug-fix.mbox --private
+
+  # Test an email patch from git format-patch
+  kci-dev patch --patch 0001-fix-memory-leak.patch
+"""
+)
 @click.option(
     "--repository",
     default="mainline",
-    help="define the kernel upstream repository where to test local changes",
+    help="Upstream kernel repository name to apply patch on (default: mainline)",
 )
-@click.option("--branch", default="master", help="define the repository branch")
+@click.option(
+    "--branch", default="master", help="Branch to apply patch on (default: master)"
+)
 @click.option(
     "--private",
     default=False,
     is_flag=True,
-    help="define if the test results will be published",
+    help="Keep test results private (not published publicly)",
 )
-@click.option("--patch", required=True, help="mbox or patch file path")
+@click.option("--patch", required=True, help="Path to patch or mbox file to test")
 @click.pass_context
 def patch(ctx, repository, branch, private, patch):
     config = ctx.obj.get("CFG")

--- a/kcidev/subcommands/results/__init__.py
+++ b/kcidev/subcommands/results/__init__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+import sys
 from functools import wraps
 
 import click
@@ -31,12 +32,47 @@ from kcidev.subcommands.results.parser import (
 
 
 @click.group(
-    help="[Experimental] Get results from the dashboard",
+    help="""[Experimental] Query and display test results from the KernelCI dashboard.
+
+This command group provides various ways to retrieve and analyze kernel test
+results from the KernelCI dashboard. You can query results by tree, branch,
+commit, architecture, and more.
+
+\b
+Available subcommands:
+  summary   - Display a summary of test results
+  trees     - List available kernel trees
+  builds    - Display build results
+  boots     - Display boot test results
+  tests     - Display test suite results
+  build     - Display details for a specific build
+  boot      - Display details for a specific boot test
+  test      - Display details for a specific test
+  hardware  - Query hardware-specific results
+
+\b
+Examples:
+  # Show summary for latest mainline commit
+  kci-dev results summary --giturl mainline --latest
+
+  # List all available trees
+  kci-dev results trees
+
+  # Show build results for a specific commit
+  kci-dev results builds --commit abc123def456
+
+  # Show test results with filtering
+  kci-dev results tests --status fail --arch x86_64
+""",
     commands={"hardware": hardware},
+    invoke_without_command=True,
 )
-def results():
+@click.pass_context
+def results(ctx):
     """Commands related to results."""
-    pass
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+        sys.exit(0)
 
 
 @results.command()

--- a/kcidev/subcommands/testretry.py
+++ b/kcidev/subcommands/testretry.py
@@ -32,10 +32,28 @@ def send_jobretry(baseurl, jobid, token):
     return response.json()
 
 
-@click.command(help="Retry a test(job) on KernelCI")
+@click.command(
+    help="""Retry a failed or incomplete test job on KernelCI.
+
+This command allows you to rerun a specific test job by providing its node ID.
+This is useful when a test fails due to infrastructure issues, timeouts, or
+other transient problems that might be resolved on a retry.
+
+The node ID can be obtained from test results or from the KernelCI dashboard.
+
+\b
+Examples:
+  # Retry a test job using its node ID
+  kci-dev testretry --nodeid 65a5c89f1234567890abcdef
+
+  # Get node ID from maestro-results and retry
+  kci-dev maestro-results --nodes --filter "status=fail" --field id --field name
+  kci-dev testretry --nodeid <NODE_ID_FROM_ABOVE>
+"""
+)
 @click.option(
     "--nodeid",
-    help="define the node id of the (test)job to retry",
+    help="Node ID of the test job to retry (obtained from test results)",
     required=True,
 )
 @click.pass_context

--- a/kcidev/subcommands/watch.py
+++ b/kcidev/subcommands/watch.py
@@ -7,20 +7,44 @@ from kcidev.libs.common import *
 from kcidev.libs.maestro_common import *
 
 
-@click.command(help="Watch completion of a test job")
+@click.command(
+    help="""Watch and monitor the completion of test jobs in real-time.
+
+This command allows you to track the progress of a test run by providing a
+node ID. It will continuously poll for updates and display the status of jobs
+as they complete. You can filter which jobs to watch and optionally check for
+specific test results.
+
+The command is useful for monitoring long-running test suites or when you need
+to know immediately when specific tests complete.
+
+\b
+Examples:
+  # Watch all jobs for a given node
+  kci-dev watch --nodeid 65a5c89f1234567890abcdef
+
+  # Watch only specific job types
+  kci-dev watch --nodeid 65a5c89f1234567890abcdef \\
+                --job-filter baseline --job-filter ltp
+
+  # Watch and return exit code based on specific test result
+  kci-dev watch --nodeid 65a5c89f1234567890abcdef \\
+                --job-filter baseline --test baseline.login
+"""
+)
 @click.option(
     "--nodeid",
-    help="define the node id of the job to watch for",
+    help="Node ID of the test run to watch (obtained from checkout or test results)",
     required=True,
 )
 @click.option(
     "--job-filter",
-    help="Job filter to trigger",
+    help="Filter jobs to watch by name (e.g., baseline, ltp). Can be used multiple times",
     multiple=True,
 )
 @click.option(
     "--test",
-    help="Return 0 if the test name supplied passed, 1 otherwise",
+    help="Watch for specific test result and set exit code (0=pass, 1=fail)",
 )
 @click.pass_context
 def watch(ctx, nodeid, job_filter, test):


### PR DESCRIPTION
This PR adds detailed help text with usage examples to all kci-dev commands.

What changed:

- Added comprehensive help text explaining each command's purpose
- Included practical usage examples for all commands
- Commands now show help instead of errors when run without parameters (where applicable)

Commands updated: bisect, checkout, commit, config, patch, results, testretry, watch