### PR TITLE
Fix results command to auto-detect git parameters from local repository

### DIFF
--- a/kcidev/libs/git_repo.py
+++ b/kcidev/libs/git_repo.py
@@ -101,6 +101,14 @@ def get_latest_commit(origin, giturl, branch):
 def set_giturl_branch_commit(origin, giturl, branch, commit, latest, git_folder):
     if not giturl or not branch or not ((commit != None) ^ latest):
         giturl, branch, commit = get_folder_repository(git_folder, branch)
+    else:
+        # Print git folder and tree info when giturl is provided
+        kci_msg("git folder: " + str(git_folder))
+        kci_msg("tree: " + giturl)
+        if branch:
+            kci_msg("branch: " + branch)
+        if commit:
+            kci_msg("commit: " + commit)
     if latest:
         commit = get_latest_commit(origin, giturl, branch)
     return giturl, branch, commit

--- a/kcidev/libs/git_repo.py
+++ b/kcidev/libs/git_repo.py
@@ -88,6 +88,97 @@ def get_folder_repository(git_folder, branch):
         raise click.Abort()
 
 
+def get_current_branch_name(git_folder):
+    """Get the current branch name from a git repository."""
+    if git_folder:
+        current_folder = git_folder
+    else:
+        current_folder = os.getcwd()
+
+    previous_folder = os.getcwd()
+    if os.path.isdir(current_folder):
+        os.chdir(current_folder)
+    else:
+        os.chdir(previous_folder)
+        return None
+
+    if is_inside_work_tree():
+        process = subprocess.Popen(
+            ["git", "branch", "--show-current"], stdout=subprocess.PIPE, text=True
+        )
+        branch_name, _ = process.communicate()
+        branch_name = branch_name.strip()
+        os.chdir(previous_folder)
+        return branch_name
+    else:
+        os.chdir(previous_folder)
+        return None
+
+
+def get_current_commit_hash(git_folder):
+    """Get the current commit hash from a git repository."""
+    if git_folder:
+        current_folder = git_folder
+    else:
+        current_folder = os.getcwd()
+
+    previous_folder = os.getcwd()
+    if os.path.isdir(current_folder):
+        os.chdir(current_folder)
+    else:
+        os.chdir(previous_folder)
+        return None
+
+    if is_inside_work_tree():
+        process = subprocess.Popen(
+            ["git", "rev-parse", "HEAD"], stdout=subprocess.PIPE, text=True
+        )
+        commit_hash, _ = process.communicate()
+        commit_hash = commit_hash.strip()
+        os.chdir(previous_folder)
+        return commit_hash
+    else:
+        os.chdir(previous_folder)
+        return None
+
+
+def get_repository_url(git_folder):
+    """Get the repository URL from a git repository."""
+    if git_folder:
+        current_folder = git_folder
+    else:
+        current_folder = os.getcwd()
+
+    previous_folder = os.getcwd()
+    if os.path.isdir(current_folder):
+        os.chdir(current_folder)
+    else:
+        os.chdir(previous_folder)
+        return None
+
+    dot_git_folder = os.path.join(current_folder, ".git")
+    if is_inside_work_tree():
+        while not os.path.exists(dot_git_folder):
+            current_folder = os.path.join(current_folder, "..")
+            dot_git_folder = os.path.join(current_folder, ".git")
+
+    if os.path.exists(dot_git_folder):
+        git_config_path = os.path.join(dot_git_folder, "config")
+        git_config = configparser.ConfigParser(strict=False)
+        git_config.read(git_config_path)
+        try:
+            git_url = git_config.get('remote "origin"', "url")
+            git_url = repository_url_cleaner(git_url)
+            os.chdir(previous_folder)
+            return git_url
+        except:
+            os.chdir(previous_folder)
+            return None
+    else:
+        os.chdir(previous_folder)
+        return None
+
+
 def get_latest_commit(origin, giturl, branch):
     trees = dashboard_fetch_tree_list(origin, False)
     for t in trees:
@@ -99,16 +190,34 @@ def get_latest_commit(origin, giturl, branch):
 
 
 def set_giturl_branch_commit(origin, giturl, branch, commit, latest, git_folder):
-    if not giturl or not branch or not ((commit != None) ^ latest):
-        giturl, branch, commit = get_folder_repository(git_folder, branch)
-    else:
-        # Print git folder and tree info when giturl is provided
-        kci_msg("git folder: " + str(git_folder))
-        kci_msg("tree: " + giturl)
-        if branch:
-            kci_msg("branch: " + branch)
-        if commit:
-            kci_msg("commit: " + commit)
+    # Fill in any missing parameters from local git repository
+    if not giturl:
+        giturl = get_repository_url(git_folder)
+        if not giturl:
+            kci_err("No git URL provided and could not determine from local repository")
+            raise click.Abort()
+
+    if not branch:
+        branch = get_current_branch_name(git_folder)
+        if not branch:
+            kci_err("No branch provided and could not determine from local repository")
+            raise click.Abort()
+
+    if not commit and not latest:
+        commit = get_current_commit_hash(git_folder)
+        if not commit:
+            kci_err("No commit provided and could not determine from local repository")
+            raise click.Abort()
+
+    # Print the final values
+    kci_msg("git folder: " + str(git_folder))
+    kci_msg("tree: " + giturl)
+    kci_msg("branch: " + branch)
+    if commit:
+        kci_msg("commit: " + commit)
+
     if latest:
         commit = get_latest_commit(origin, giturl, branch)
+        kci_msg("commit: " + commit)
+
     return giturl, branch, commit


### PR DESCRIPTION
This PR improves the usability of the kci-dev results command by automatically detecting missing git parameters (URL, branch, commit) from the local git repository.

Previously, when using --giturl without specifying --branch, the command would fall back to using the default repository settings, often resulting in incorrect tree URLs being displayed and API errors. This made it cumbersome to check results for specific commits while working on a development branch.

The changes refactor set_giturl_branch_commit() to intelligently fill in any missing parameters from the local git repository:
- If --giturl is provided but --branch is missing, it uses the current branch from the local repo
- If --commit is missing (and --latest isn't specified), it uses the current HEAD commit
- If --giturl is missing, it uses the origin URL from the local repo

This is particularly useful when working on a development branch and wanting to check results for specific commits. For example:

# Check results for a specific commit on your current branch
kci-dev results summary --commit abc123def

# Use a different git URL but keep your current branch context (because, for example, my local git might point to a gitolite variant)
kci-dev results summary --giturl https://git.kernel.org/pub/scm/linux/kernel/git/sashal/linus-next.git --commit abc123def