### PR TITLE
Enable `--days` switch for getting tree list

### DIFF
--- a/kcidev/libs/dashboard.py
+++ b/kcidev/libs/dashboard.py
@@ -187,9 +187,10 @@ def dashboard_fetch_build(build_id, use_json):
     return dashboard_api_fetch(endpoint, {}, use_json)
 
 
-def dashboard_fetch_tree_list(origin, use_json):
+def dashboard_fetch_tree_list(origin, use_json, days=7):
     params = {
         "origin": origin,
+        "interval_in_days": days,
     }
     logging.info(f"Fetching tree list for origin: {origin}")
     return dashboard_api_fetch("tree-fast", params, use_json)

--- a/kcidev/subcommands/results/__init__.py
+++ b/kcidev/subcommands/results/__init__.py
@@ -92,10 +92,16 @@ def summary(origin, git_folder, giturl, branch, commit, latest, arch, tree, use_
     help="Select KCIDB origin",
     default="maestro",
 )
+@click.option(
+    "--days",
+    help="Provide a period of time in days to get results for",
+    type=int,
+    default=7,
+)
 @results_display_options
-def trees(origin, use_json):
+def trees(origin, use_json, days):
     """List trees from a give origin."""
-    cmd_list_trees(origin, use_json)
+    cmd_list_trees(origin, use_json, days)
 
 
 @results.command()

--- a/kcidev/subcommands/results/parser.py
+++ b/kcidev/subcommands/results/parser.py
@@ -149,11 +149,10 @@ def get_command_summary(command_data):
     return inconclusive_cmd, pass_cmd, fail_cmd
 
 
-def cmd_list_trees(origin, use_json):
+def cmd_list_trees(origin, use_json, days):
     logging.info(f"Listing trees for origin: {origin}")
-    trees = dashboard_fetch_tree_list(origin, use_json)
+    trees = dashboard_fetch_tree_list(origin, use_json, days)
     logging.debug(f"Found {len(trees)} trees")
-
     if use_json:
         kci_msg(json.dumps(list(map(lambda t: create_tree_json(t), trees))))
         return


### PR DESCRIPTION
For the command `kci-dev results trees`, add `--days` option to provide a period of time in days to
get results for.

Closes https://github.com/kernelci/kci-dev/issues/176