### PR TITLE
Fix `kci-dev results builds` command

### DIFF
--- a/kcidev/subcommands/results/__init__.py
+++ b/kcidev/subcommands/results/__init__.py
@@ -120,6 +120,11 @@ def builds(
     git_branch,
     count,
     use_json,
+    hardware,
+    test_path,
+    compatible,
+    min_duration,
+    max_duration,
 ):
     """Display build results."""
     giturl, branch, commit = set_giturl_branch_commit(


### PR DESCRIPTION
Fix the below error related to missing command line options in command `builds` definition.
```
File "kcidev/subcommands/results/options.py", line 117, in wrapper
   return func(*args, **kwargs)
          ^^^^^^^^^^^^^^^^^^^^^
TypeError: builds() got an unexpected keyword argument 'hardware'
```
Issue introduced by PR: https://github.com/kernelci/kci-dev/pull/175