### PR TITLE
fix(results): remove invalid nl parameter from kci_msg_nonl calls

### DIFF
--- a/kcidev/subcommands/results/parser.py
+++ b/kcidev/subcommands/results/parser.py
@@ -27,9 +27,9 @@ from kcidev.libs.job_filters import HardwareRegexFilter, TestRegexFilter, TreeFi
 def print_summary(type, n_pass, n_fail, n_inconclusive):
 
     kci_msg_nonl(f"{type}:\t")
-    kci_msg_green(f"{n_pass}") if n_pass else kci_msg_nonl(f"{n_pass}", nl=False)
+    kci_msg_green(f"{n_pass}", nl=False) if n_pass else kci_msg_nonl(f"{n_pass}")
     kci_msg_nonl("/")
-    kci_msg_red(f"{n_fail}") if n_fail else kci_msg_nonl(f"{n_fail}", nl=False)
+    kci_msg_red(f"{n_fail}", nl=False) if n_fail else kci_msg_nonl(f"{n_fail}")
     kci_msg_nonl("/")
     (
         kci_msg_yellow(f"{n_inconclusive}", nl=False)


### PR DESCRIPTION
The kci_msg_nonl() function doesn't accept any parameters, but was being called with nl=False in print_summary(), causing a TypeError:

TypeError: kci_msg_nonl() got an unexpected keyword argument 'nl'

This fix removes the invalid parameter and uses the nl parameter correctly on the color message functions (kci_msg_green, kci_msg_red) instead.

Fixes: 19ae4b536e89 ("Add print summary function")