### PR TITLE
Validate builds history

### DIFF
--- a/kcidev/libs/git_repo.py
+++ b/kcidev/libs/git_repo.py
@@ -428,15 +428,11 @@ def set_giturl_branch_commit(origin, giturl, branch, commit, latest, git_folder)
     return giturl, branch, commit
 
 
-def get_tree_name(origin, giturl, branch, commit):
-    """Get tree name from git URL, branch, and commit"""
+def get_tree_name(origin, giturl, branch):
+    """Get tree name from git URL, and branch"""
     trees = dashboard_fetch_tree_list(origin, False)
 
     for t in trees:
-        if (
-            t["git_repository_url"] == giturl
-            and t["git_repository_branch"] == branch
-            and t["git_commit_hash"] == commit
-        ):
+        if t["git_repository_url"] == giturl and t["git_repository_branch"] == branch:
             return t["tree_name"]
     return None

--- a/kcidev/subcommands/validate/__init__.py
+++ b/kcidev/subcommands/validate/__init__.py
@@ -4,6 +4,7 @@ import click
 
 from kcidev.subcommands.validate.boots import boots
 from kcidev.subcommands.validate.builds import builds
+from kcidev.subcommands.validate.builds_history import builds_history
 
 
 @click.group(
@@ -13,6 +14,7 @@ from kcidev.subcommands.validate.builds import builds
 Subcommands:
     builds - Validate build results
     boots  - Validate boot results
+    builds-history - Validate builds history
 
 \b
 Examples:
@@ -22,6 +24,9 @@ Examples:
     # Validate boots
     kci-dev validate boots --all-checkouts --days <number-of-days>
     kci-dev validate boots -commit <git-commit> --giturl <git-url> --branch <git-branch>
+    # Validate builds history
+    kci-dev validate builds-history --all-checkouts --days <number-of-days> --arch <architecture-filter>
+    kci-dev validate builds-history -commit <git-commit> --giturl <git-url> --branch <git-branch> --days <number-of-days>
 """,
     invoke_without_command=True,
 )
@@ -36,6 +41,7 @@ def validate(ctx):
 # Add subcommands to the validate group
 validate.add_command(builds)
 validate.add_command(boots)
+validate.add_command(builds_history)
 
 
 if __name__ == "__main__":

--- a/kcidev/subcommands/validate/boots.py
+++ b/kcidev/subcommands/validate/boots.py
@@ -105,7 +105,7 @@ def boots(
         giturl, branch, commit = set_giturl_branch_commit(
             origin, giturl, branch, commit, latest, git_folder
         )
-        tree_name = get_tree_name(origin, giturl, branch, commit)
+        tree_name = get_tree_name(origin, giturl, branch)
         stats = get_boot_stats(ctx, giturl, branch, commit, tree_name, verbose, arch)
         if stats:
             final_stats.append(stats)

--- a/kcidev/subcommands/validate/builds.py
+++ b/kcidev/subcommands/validate/builds.py
@@ -105,7 +105,7 @@ def builds(
         giturl, branch, commit = set_giturl_branch_commit(
             origin, giturl, branch, commit, latest, git_folder
         )
-        tree_name = get_tree_name(origin, giturl, branch, commit)
+        tree_name = get_tree_name(origin, giturl, branch)
         stats = get_build_stats(ctx, giturl, branch, commit, tree_name, verbose, arch)
         if stats:
             final_stats.append(stats)

--- a/kcidev/subcommands/validate/builds_history.py
+++ b/kcidev/subcommands/validate/builds_history.py
@@ -1,0 +1,99 @@
+import click
+
+from kcidev.libs.git_repo import get_tree_name
+from kcidev.subcommands.results import trees
+
+from .helper import get_builds_history_stats, print_stats
+
+
+@click.command(
+    name="builds-history",
+    help="""Validate dashboard builds history with maestro.
+
+The command can be used to check if number of builds is consitent
+for different checkouts of the same git tree/branch.
+`--days` option is used to fetch checkouts created during the mentioned days.
+Default is `7` days.
+
+\b
+Examples:
+    kci-dev validate builds-history --all-checkouts --days <number-of-days>
+    kci-dev validate builds-history --giturl <git-url> --branch <git-branch> --days <number-of-days>
+""",
+)
+@click.option(
+    "--all-checkouts",
+    is_flag=True,
+    help="Get build validation stats for all available checkouts",
+)
+@click.option(
+    "--days",
+    help="Provide a period of time in days to get results for",
+    type=int,
+    default="7",
+)
+@click.option(
+    "--origin",
+    help="Select KCIDB origin",
+    default="maestro",
+)
+@click.option(
+    "--giturl",
+    help="Git URL of kernel tree",
+)
+@click.option(
+    "--branch",
+    help="Branch to get results for",
+)
+@click.option("--arch", help="Filter by arch")
+@click.option(
+    "--verbose",
+    is_flag=True,
+    default=False,
+    help="Get detailed output",
+)
+@click.pass_context
+def builds_history(
+    ctx,
+    all_checkouts,
+    origin,
+    giturl,
+    branch,
+    arch,
+    days,
+    verbose,
+):
+    final_stats = []
+    print("Fetching builds history information...")
+    if all_checkouts:
+        if giturl or branch:
+            raise click.UsageError(
+                "Cannot use --all-checkouts with --giturl or --branch"
+            )
+        trees_list = ctx.invoke(trees, origin=origin, days=days, verbose=False)
+        for tree in trees_list:
+            giturl = tree["git_repository_url"]
+            branch = tree["git_repository_branch"]
+            tree_name = tree["tree_name"]
+            stats = get_builds_history_stats(
+                ctx, giturl, branch, tree_name, arch, days, verbose
+            )
+            if stats:
+                final_stats.extend(stats)
+    else:
+        tree_name = get_tree_name(origin, giturl, branch)
+        final_stats = get_builds_history_stats(
+            ctx, giturl, branch, tree_name, arch, days, verbose
+        )
+    if final_stats:
+        headers = [
+            "tree/branch",
+            "Commit",
+            "Maestro\nbuilds",
+            "Dashboard\nbuilds",
+            "Build count\ncomparison",
+            "Missing build IDs",
+        ]
+        max_col_width = [None, 40, 3, 3, 2, 30]
+        table_fmt = "simple_grid"
+        print_stats(final_stats, headers, max_col_width, table_fmt)


### PR DESCRIPTION
Implement `validate builds-history` command.
    
A builds history command to validate if number of builds is consistent for multiple checkouts of the same git  tree/branch.