### PR TITLE
Implement `detect issues` command

### DIFF
--- a/kcidev/libs/dashboard.py
+++ b/kcidev/libs/dashboard.py
@@ -58,7 +58,7 @@ def _dashboard_request(func):
                         kci_msg(data)
                     else:
                         kci_msg("json error: " + str(data["error"]))
-                    raise click.Abort()
+                    raise click.ClickException(data.get("error"))
 
                 logging.info(f"Successfully completed {func.__name__} request")
                 return data
@@ -266,3 +266,15 @@ def dashboard_fetch_hardware_tests(name, origin, use_json):
     return dashboard_api_post(
         f"hardware/{urllib.parse.quote_plus(name)}/tests", {}, use_json, body
     )
+
+
+def dashboard_fetch_build_issues(build_id, use_json):
+    endpoint = f"build/{build_id}/issues"
+    logging.info(f"Fetching build issues for build ID: {build_id}")
+    return dashboard_api_fetch(endpoint, {}, use_json)
+
+
+def dashboard_fetch_boot_issues(test_id, use_json):
+    endpoint = f"test/{test_id}/issues"
+    logging.info(f"Fetching test issues for test ID: {test_id}")
+    return dashboard_api_fetch(endpoint, {}, use_json)

--- a/kcidev/main.py
+++ b/kcidev/main.py
@@ -11,6 +11,7 @@ from kcidev.subcommands import (
     checkout,
     commit,
     config,
+    detect,
     maestro,
     results,
     testretry,
@@ -61,6 +62,7 @@ def run():
     cli.add_command(checkout.checkout)
     cli.add_command(commit.commit)
     cli.add_command(config.config)
+    cli.add_command(detect.detect)
     cli.add_command(maestro.maestro)
     cli.add_command(testretry.testretry)
     cli.add_command(results.results)

--- a/kcidev/subcommands/detect/__init__.py
+++ b/kcidev/subcommands/detect/__init__.py
@@ -1,0 +1,39 @@
+import sys
+
+import click
+
+from kcidev.subcommands.detect.issues import issues
+
+
+@click.group(
+    help="""Detect dashboard issues for builds and boots
+
+\b
+Subcommands:
+  issues - Fetch KCIDB issues for builds/boots
+
+\b
+Examples:
+  # Detect build issues
+  kci-dev detect issues --builds --id <build-id>
+  kci-dev detect issues --builds --all-checkouts --days <number-of-days> --origin <origin>
+  # Detect boot issues
+  kci-dev detect issues --boots --id <boot-id>
+  kci-dev detect issues --boots --all-checkouts --days <number-of-days> --origin <origin>
+""",
+    invoke_without_command=True,
+)
+@click.pass_context
+def detect(ctx):
+    """Commands related to results validation"""
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+        sys.exit(0)
+
+
+# Add subcommands to the detect group
+detect.add_command(issues)
+
+
+if __name__ == "__main__":
+    main_kcidev()

--- a/kcidev/subcommands/detect/helper.py
+++ b/kcidev/subcommands/detect/helper.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+
+import click
+from tabulate import tabulate
+
+from kcidev.libs.common import kci_msg_red
+from kcidev.libs.dashboard import (
+    dashboard_fetch_boot_issues,
+    dashboard_fetch_build_issues,
+)
+from kcidev.subcommands.results import boots, builds
+
+
+def get_issues(ctx, origin, item_type, giturl, branch, commit, tree_name, arch):
+    """Get KCIDB issues for builds/boots"""
+    try:
+        if item_type == "builds":
+            results_cmd = builds
+            dashboard_func = dashboard_fetch_build_issues
+        elif item_type == "boots":
+            results_cmd = boots
+            dashboard_func = dashboard_fetch_boot_issues
+        else:
+            kci_msg_red("Please specify 'builds' or 'boots' as items type")
+            return []
+
+        dashboard_items = ctx.invoke(
+            results_cmd,
+            origin=origin,
+            giturl=giturl,
+            branch=branch,
+            commit=commit,
+            status="all",
+            count=True,
+            verbose=False,
+            arch=arch,
+        )
+        final_stats = []
+        for item in dashboard_items:
+            # Exclude passed builds/boots
+            if item["status"] == "PASS":
+                continue
+            item_id = item["id"]
+            try:
+                issues = dashboard_func(item_id, False)
+                issue_ids = []
+                for issue in issues:
+                    issue_ids.append(issue["id"])
+                final_stats.append([f"{tree_name}/{branch}", item_id, issue_ids])
+            except click.ClickException as e:
+                if e.message in (
+                    "No issues were found for this build",
+                    "No issues were found for this test",
+                ):
+                    final_stats.append([f"{tree_name}/{branch}", item_id, []])
+        return final_stats
+    except click.Abort:
+        kci_msg_red(
+            f"{tree_name}/{branch}: Aborted while fetching dashboard builds/boots"
+        )
+        return []
+    except click.ClickException as e:
+        kci_msg_red(f"{tree_name}/{branch}: {e.message}")
+        return []
+
+
+def get_issues_for_specific_item(item_type, item_id):
+    """Get KCIDB issues for a specific build/boot matching provided ID"""
+    try:
+        if item_type == "builds":
+            dashboard_func = dashboard_fetch_build_issues
+        elif item_type == "boots":
+            dashboard_func = dashboard_fetch_boot_issues
+        else:
+            kci_msg_red("Please specify 'builds' or 'boots' as items type")
+            return []
+        issues = dashboard_func(item_id, False)
+        issue_ids = []
+        for issue in issues:
+            issue_ids.append(issue["id"])
+        stats = [[item_id, issue_ids]]
+        return stats
+    except click.ClickException as e:
+        if e.message == "No issues were found for this build":
+            stats = [[item_id, []]]
+            return stats
+        return None
+
+
+def print_stats(data, headers, max_col_width, table_fmt):
+    """Print build statistics in tabular format"""
+    print("Creating a stats report...")
+    print(
+        tabulate(data, headers=headers, maxcolwidths=max_col_width, tablefmt=table_fmt)
+    )

--- a/kcidev/subcommands/detect/issues.py
+++ b/kcidev/subcommands/detect/issues.py
@@ -1,0 +1,123 @@
+import click
+
+from kcidev.subcommands.detect.helper import (
+    get_issues,
+    get_issues_for_specific_item,
+    print_stats,
+)
+from kcidev.subcommands.results import trees
+
+
+@click.command(
+    name="issues",
+    help="""Detect KCIDB issues for builds and boots
+
+\b
+The command is used to fetch KCIDB issues associated with builds and boots.
+Provide `--builds` and `--boots` option for builds issue detection and boots
+issue detection respectively.
+`--all-checkouts` option can be used to fetch KCIDB issues for all the
+failed and inconclusive builds/boots from all available trees on the dashboard.
+Issues for a single build/boot can be retrieved by providing `--id`
+option.
+  
+\b
+Examples:
+  # Detect build issues
+  kci-dev detect issues --builds --id <build-id>
+  kci-dev detect issues --builds --all-checkouts --days <number-of-days> --origin <origin>
+  # Detect boot issues
+  kci-dev detect issues --boots --id <boot-id>
+  kci-dev detect issues --boots --all-checkouts --days <number-of-days> --origin <origin>
+""",
+)
+@click.option(
+    "--origin",
+    help="Select KCIDB origin",
+    default="maestro",
+)
+@click.option(
+    "--builds",
+    is_flag=True,
+    help="Fetch KCIDB issues for builds",
+)
+@click.option(
+    "--boots",
+    is_flag=True,
+    help="Fetch KCIDB issues for boots",
+)
+@click.option(
+    "--id",
+    "item_id",
+    help="Build/boot id to get issues for",
+)
+@click.option(
+    "--all-checkouts",
+    is_flag=True,
+    help="Fetch KCIDB issues for all failed/inconclusive builds/boots of all available checkouts",
+)
+@click.option("--arch", help="Filter by arch")
+@click.option(
+    "--days",
+    help="Provide a period of time in days to get results for",
+    type=int,
+    default="7",
+)
+@click.pass_context
+def issues(
+    ctx,
+    origin,
+    builds,
+    boots,
+    item_id,
+    all_checkouts,
+    arch,
+    days,
+):
+
+    if not (builds or boots):
+        raise click.UsageError("Provide --builds or --boots to fetch issues for")
+
+    if builds and boots:
+        raise click.UsageError("Specify only one option from --builds and --boots")
+
+    item_type = "builds" if builds else "boots"
+
+    if not (all_checkouts or item_id):
+        raise click.UsageError("Provide --all-checkouts or --id")
+
+    print("Fetching KCIDB issues...")
+    if all_checkouts:
+        if item_id:
+            raise click.UsageError("Cannot use --all-checkouts with --id")
+        final_stats = []
+        trees_list = ctx.invoke(trees, origin=origin, days=days, verbose=False)
+        for tree in trees_list:
+            giturl = tree["git_repository_url"]
+            branch = tree["git_repository_branch"]
+            commit = tree["git_commit_hash"]
+            tree_name = tree["tree_name"]
+            stats = get_issues(
+                ctx, origin, item_type, giturl, branch, commit, tree_name, arch
+            )
+            final_stats.extend(stats)
+        if final_stats:
+            headers = [
+                "tree/branch",
+                "ID",
+                "Issues",
+            ]
+            max_col_width = [None, None, None]
+            table_fmt = "simple_grid"
+            print_stats(final_stats, headers, max_col_width, table_fmt)
+
+    elif item_id:
+        stats = get_issues_for_specific_item(item_type, item_id)
+        if stats:
+            headers = [
+                "ID",
+                "Issues",
+            ]
+            max_col_width = [None, None]
+            table_fmt = "simple_grid"
+            print_stats(stats, headers, max_col_width, table_fmt)

--- a/kcidev/subcommands/results/parser.py
+++ b/kcidev/subcommands/results/parser.py
@@ -202,6 +202,7 @@ def cmd_builds(
     logging.debug(f"Created filter set with {len(filter_set.filters)} filters")
 
     filtered_builds = 0
+    filtered_builds_list = []
     builds = []
     total_builds = len(data["builds"])
     logging.debug(f"Processing {total_builds} builds")
@@ -209,7 +210,7 @@ def cmd_builds(
     for build in data["builds"]:
         if not filter_set.matches(build):
             continue
-
+        filtered_builds_list.append(build)
         log_path = build["log_url"]
         if download_logs:
             try:
@@ -234,7 +235,7 @@ def cmd_builds(
         kci_msg(filtered_builds)
     elif use_json:
         kci_msg(json.dumps(builds))
-    return data["builds"]
+    return filtered_builds_list
 
 
 def print_build(build, log_path):


### PR DESCRIPTION
The command is used to fetch KCIDB issues associated with builds/boots. 
Provide `--builds` and `--boots` option for getting builds and boots issues respectively.
`--all-checkouts` option can be used to fetch KCIDB issues for all the failed and inconclusive builds/boots from all available trees on the dashboard. Issues for a single build can be retrieved by providing `--id` option.