### PR TITLE
Update filters for getting builds to validate

### DIFF
--- a/kcidev/subcommands/maestro/validate/helper.py
+++ b/kcidev/subcommands/maestro/validate/helper.py
@@ -17,7 +17,6 @@ def get_builds(ctx, giturl, branch, commit, arch):
     dashboard_builds = []
     filters = [
         "kind=kbuild",
-        "data.error_code__ne=node_timeout",  # maestro doesn't submit timed-out nodes
         "data.kernel_revision.url=" + giturl,
         "data.kernel_revision.branch=" + branch,
         "data.kernel_revision.commit=" + commit,


### PR DESCRIPTION
Remove filter to exclude timed-out builds while getting builds from maestro.
This is due to maestro started sending timed-out builds to KCIDB as per the latest changes.
Reference: https://github.com/kernelci/kernelci-pipeline/pull/1227