### PR TITLE
Implement a set of `results issues` command

### DIFF
--- a/kcidev/libs/dashboard.py
+++ b/kcidev/libs/dashboard.py
@@ -292,3 +292,29 @@ def dashboard_fetch_boot_issues(test_id, use_json):
     endpoint = f"test/{test_id}/issues"
     logging.info(f"Fetching test issues for test ID: {test_id}")
     return dashboard_api_fetch(endpoint, {}, use_json)
+
+
+def dashboard_fetch_issue_list(origin, days, use_json):
+    params = {
+        "filter_origin": origin,
+        "interval_in_days": days,
+    }
+    logging.info(f"Fetching issue list for origin: {origin}")
+    return dashboard_api_fetch("issue/", params, use_json)
+
+
+def dashboard_fetch_issue(issue_id, use_json):
+    logging.info(f"Fetching issue details for issue ID: {issue_id}")
+    return dashboard_api_fetch(f"issue/{issue_id}", {}, use_json)
+
+
+def dashboard_fetch_issue_builds(origin, issue_id, use_json):
+    logging.info(f"Fetching builds for issue ID: {issue_id}")
+    params = {"filter_origin": origin}
+    return dashboard_api_fetch(f"issue/{issue_id}/builds", params, use_json)
+
+
+def dashboard_fetch_issue_tests(origin, issue_id, use_json):
+    logging.info(f"Fetching tests for issue ID: {issue_id}")
+    params = {"filter_origin": origin}
+    return dashboard_api_fetch(f"issue/{issue_id}/tests", params, use_json)

--- a/kcidev/subcommands/results/__init__.py
+++ b/kcidev/subcommands/results/__init__.py
@@ -16,6 +16,7 @@ from kcidev.libs.dashboard import (
 )
 from kcidev.libs.git_repo import set_giturl_branch_commit
 from kcidev.subcommands.results.hardware import hardware
+from kcidev.subcommands.results.issues import issues
 from kcidev.subcommands.results.options import (
     builds_and_tests_options,
     common_options,
@@ -53,22 +54,22 @@ Available subcommands:
   test      - Display details for a specific test
   hardware  - Query hardware-specific results
   compare   - Compare test results between commits
+  issues    - Query KCIDB issues
 
 \b
 Examples:
   # Show summary for latest mainline commit
   kci-dev results summary --giturl mainline --latest
-
   # List all available trees
   kci-dev results trees
-
   # Show build results for a specific commit
   kci-dev results builds --commit abc123def456
-
   # Show test results with filtering
   kci-dev results tests --status fail --arch x86_64
+  # Display KCIDB issues
+  kci-dev results issues list
 """,
-    commands={"hardware": hardware},
+    commands={"hardware": hardware, "issues": issues},
     invoke_without_command=True,
 )
 @click.pass_context

--- a/kcidev/subcommands/results/issues.py
+++ b/kcidev/subcommands/results/issues.py
@@ -1,0 +1,146 @@
+import sys
+
+import click
+
+from kcidev.libs.dashboard import (
+    dashboard_fetch_issue,
+    dashboard_fetch_issue_builds,
+    dashboard_fetch_issue_list,
+    dashboard_fetch_issue_tests,
+)
+from kcidev.subcommands.results.options import results_display_options
+from kcidev.subcommands.results.parser import cmd_issue_list, print_data
+
+
+@click.group(
+    help="""Get KCIDB issues from the dashboard
+
+\b
+Subcommands:
+    results issues list   - Get all KCIDB issues
+    results issues get    - Get an issue matching ID
+    results issues builds - Get builds associated with an issue
+    results issues tests  - Get tests associated with an issue
+
+\b
+Examples:
+    # Get issues
+    kci-dev results issues list --days <number-of-days> --origin <origin>
+    # Get an issue information matching issue ID
+    kci-dev results issues get --id <id>
+    # Get builds associated with an issue ID
+    kci-dev results issues builds --id <id> --origin <origin>
+    # Get tests associated with an issue ID
+    kci-dev results issues tests --id <id> --origin <origin>
+""",
+    invoke_without_command=True,
+)
+@click.pass_context
+def issues(ctx):
+    """Commands related to KCIDB issues"""
+    if ctx.invoked_subcommand is None:
+        click.echo(ctx.get_help())
+        sys.exit(0)
+
+
+@issues.command(
+    name="list",
+    help="""Fetch KCIDB issues from the dashboard
+
+\b
+Examples:
+  kci-dev results issues list --origin <origin> --days <number-of-days>
+""",
+)
+@click.option(
+    "--origin",
+    help="Select KCIDB origin",
+    default="maestro",
+)
+@click.option(
+    "--days",
+    help="Provide a period of time in days to get results for",
+    type=int,
+    default="5",
+)
+@results_display_options
+def issues_list(origin, days, use_json):
+    """Issue list command handler"""
+    data = dashboard_fetch_issue_list(origin, days, use_json)
+    cmd_issue_list(data, use_json)
+
+
+@issues.command(
+    name="get",
+    help="""Fetch KCIDB issue matching provided ID
+
+\b
+Examples:
+  kci-dev results issues get --id <id>
+""",
+)
+@click.option(
+    "--id",
+    "issue_id",
+    required=True,
+    help="Issue ID to get information for",
+)
+@results_display_options
+def get(issue_id, use_json):
+    """Get issue command handler"""
+    data = dashboard_fetch_issue(issue_id, use_json)
+    print_data(data, use_json)
+
+
+@issues.command(
+    name="builds",
+    help="""Fetch builds associated with KCIDB issue
+
+\b
+Examples:
+  kci-dev results issues builds --id <id> --origin <origin>
+""",
+)
+@click.option(
+    "--origin",
+    help="Select KCIDB origin",
+    default="maestro",
+)
+@click.option(
+    "--id",
+    "issue_id",
+    required=True,
+    help="Issue ID to get information for",
+)
+@results_display_options
+def builds(origin, issue_id, use_json):
+    """Builds command handler"""
+    data = dashboard_fetch_issue_builds(origin, issue_id, use_json)
+    print_data(data, use_json)
+
+
+@issues.command(
+    name="tests",
+    help="""Fetch tests associated with KCIDB issue
+
+\b
+Examples:
+  kci-dev results issues tests --id <id> --origin <origin>
+""",
+)
+@click.option(
+    "--origin",
+    help="Select KCIDB origin",
+    default="maestro",
+)
+@click.option(
+    "--id",
+    "issue_id",
+    required=True,
+    help="Issue ID to get information for",
+)
+@results_display_options
+def tests(origin, issue_id, use_json):
+    """Tests command handler"""
+    data = dashboard_fetch_issue_tests(origin, issue_id, use_json)
+    print_data(data, use_json)

--- a/kcidev/subcommands/results/parser.py
+++ b/kcidev/subcommands/results/parser.py
@@ -920,3 +920,19 @@ def cmd_compare(origin, giturl, branch, commits, use_json):
 
         if total_regressions == 0:
             kci_msg("✅ No regressions found - all status changes are expected")
+
+
+def cmd_issue_list(data, use_json):
+    """Display KCIDB issues"""
+    if use_json:
+        kci_msg_json(data["issues"])
+    else:
+        kci_msg(data["issues"])
+
+
+def print_data(data, use_json):
+    """Print a list of dictionary"""
+    if use_json:
+        kci_msg_json(data)
+    else:
+        kci_msg(data)


### PR DESCRIPTION
A set of command to get the below information:
- Get issues
- Get issue information matching an ID
- Get builds associated with an issue
- Get tests associated with an issue