### PR TITLE
validate builds: improve output format with simple list view

### DIFF
--- a/kcidev/libs/common.py
+++ b/kcidev/libs/common.py
@@ -129,6 +129,10 @@ def kci_msg_nonl(content):
     click.echo(content, nl=False)
 
 
+def kci_msg_bold_nonl(content):
+    click.secho(content, bold=True, nl=False)
+
+
 def kci_msg_green(content, nl=True):
     click.secho(content, fg="green", nl=nl)
 

--- a/kcidev/subcommands/maestro/validate/boots.py
+++ b/kcidev/subcommands/maestro/validate/boots.py
@@ -3,7 +3,7 @@ import click
 from kcidev.libs.git_repo import get_tree_name, set_giturl_branch_commit
 from kcidev.subcommands.results import trees
 
-from .helper import get_boot_stats, print_stats
+from .helper import get_boot_stats, print_table_stats
 
 
 @click.command(
@@ -121,4 +121,4 @@ def boots(
         ]
         max_col_width = [None, 40, 3, 3, 2, 30, 30]
         table_fmt = "simple_grid"
-        print_stats(final_stats, headers, max_col_width, table_fmt)
+        print_table_stats(final_stats, headers, max_col_width, table_fmt)

--- a/kcidev/subcommands/maestro/validate/builds.py
+++ b/kcidev/subcommands/maestro/validate/builds.py
@@ -3,7 +3,12 @@ import click
 from kcidev.libs.git_repo import get_tree_name, set_giturl_branch_commit
 from kcidev.subcommands.results import trees
 
-from .helper import get_build_stats, get_builds_history_stats, print_stats
+from .helper import (
+    get_build_stats,
+    get_builds_history_stats,
+    print_simple_list,
+    print_table_stats,
+)
 
 
 @click.command(
@@ -27,7 +32,7 @@ by providing --history option.
 Examples:
     # Build validation
     kci-dev validate builds --all-checkouts --days <number-of-days>
-    kci-dev validate builds -commit <git-commit> --giturl <git-url> --branch <git-branch>
+    kci-dev validate builds --commit <git-commit> --giturl <git-url> --branch <git-branch>
     # Build history validation
     kci-dev validate builds --history --all-checkouts --days <number-of-days>
     kci-dev validate builds --history --giturl <git-url> --branch <git-branch> --days <number-of-days>
@@ -82,6 +87,12 @@ Examples:
     default=False,
     help="Get detailed output",
 )
+@click.option(
+    "--table-output",
+    is_flag=True,
+    default=False,
+    help="Display results in table format instead of simple list",
+)
 @click.pass_context
 def builds(
     ctx,
@@ -96,6 +107,7 @@ def builds(
     days,
     history,
     verbose,
+    table_output,
 ):
     final_stats = []
     print("Fetching build information...")
@@ -164,4 +176,7 @@ def builds(
             ]
             max_col_width = [None, 40, 3, 3, 2, 30, 30]
         table_fmt = "simple_grid"
-        print_stats(final_stats, headers, max_col_width, table_fmt)
+        if table_output:
+            print_table_stats(final_stats, headers, max_col_width, table_fmt)
+        else:
+            print_simple_list(final_stats, history)


### PR DESCRIPTION
Add new simple list output format as default for maestro validate builds command. The new format provides a cleaner, more readable view that:

- Shows tree/branch with ✅/❌ status indicators
- Lists commit hashes and missing build IDs with clickable links
- Groups results by tree/branch in history mode
- Focuses on highlighting discrepancies

Changes:
- Add print_simple_list() function with history and non-history modes
- Rename print_stats() to print_table_stats() for clarity
- Add --table-output option to use original table format
- Add kci_msg_bold_nonl() helper function for formatted output
- Update imports in boots.py to use renamed function

The simple list format is now the default, with --table-output available for users who prefer the detailed table view.