### PR TITLE
`maestro validate builds` command fixes

### DIFF
--- a/kcidev/libs/common.py
+++ b/kcidev/libs/common.py
@@ -129,8 +129,8 @@ def kci_msg_nonl(content):
     click.echo(content, nl=False)
 
 
-def kci_msg_bold_nonl(content):
-    click.secho(content, bold=True, nl=False)
+def kci_msg_bold(content, nl=True):
+    click.secho(content, bold=True, nl=nl)
 
 
 def kci_msg_green(content, nl=True):

--- a/kcidev/subcommands/maestro/validate/builds.py
+++ b/kcidev/subcommands/maestro/validate/builds.py
@@ -179,4 +179,4 @@ def builds(
         if table_output:
             print_table_stats(final_stats, headers, max_col_width, table_fmt)
         else:
-            print_simple_list(final_stats, history)
+            print_simple_list(final_stats, "builds", history)


### PR DESCRIPTION
1. Fix `print_simple_list` function:
- Add list of commits tested for builds history output
- Add number of missing builds to the ouput
2. Add `item_type` to `print_simple_list` to make it generic for builds and boots
3. Include commits in the output for which 0 builds are detected from the dashboard