### PR TITLE
kcidev/libs/dashboard: use `tree` endpoint instead of `tree-fast`

### DIFF
--- a/kcidev/libs/dashboard.py
+++ b/kcidev/libs/dashboard.py
@@ -218,7 +218,7 @@ def dashboard_fetch_tree_list(origin, use_json, days=7):
         "interval_in_days": days,
     }
     logging.info(f"Fetching tree list for origin: {origin}")
-    return dashboard_api_fetch("tree-fast", params, use_json)
+    return dashboard_api_fetch("tree", params, use_json)
 
 
 def dashboard_fetch_hardware_list(origin, use_json):


### PR DESCRIPTION
Use `/tree` endpoint for fetching tree list as `/tree-fast` is not returning more than one entry for the same `git_url`, while /tree allows that.