### PR TITLE
Fix filter for getting boot results from maestro

### DIFF
--- a/kcidev/subcommands/maestro/validate/helper.py
+++ b/kcidev/subcommands/maestro/validate/helper.py
@@ -260,6 +260,7 @@ def get_boots(ctx, giturl, branch, commit, arch):
         "data.kernel_revision.url=" + giturl,
         "data.kernel_revision.branch=" + branch,
         "data.kernel_revision.commit=" + commit,
+        "state=done",
     ]
     if arch:
         filters.append(f"data.arch={arch}")


### PR DESCRIPTION
Maestro is sending completed boots to KCIDB.
And that would appear on dashboard. Fix the filter for getting boots from maestro.