### PR TITLE
(pyproject): Update dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,8 @@ gitpython = "^3.1.43"
 tomli = { version = "^2.2.1", python = "<3.11" }
 pyyaml = "^6.0.2"
 tabulate = "0.9.0"
-matplotlib = "3.10.6"
-mplcursors = "0.7"
+matplotlib = ">=3.6"
+mplcursors = ">=0.6"
 
 [tool.poetry.scripts]
 kci-dev = 'kcidev.main:run'


### PR DESCRIPTION
pyproject.toml:
- loosen dependency on matplotlib and mplcursors for distro compatibility
- Strict click to version less than 8.3.0 # issue https://github.com/kernelci/kci-dev/issues/222