### PR TITLE
maestro: add JSON validation reports and --fail-on-mismatch flag

### DIFF
--- a/kcidev/subcommands/maestro/validate/boots.py
+++ b/kcidev/subcommands/maestro/validate/boots.py
@@ -1,9 +1,17 @@
+import sys
+
 import click
 
 from kcidev.libs.git_repo import get_tree_name, set_giturl_branch_commit
 from kcidev.subcommands.results import trees
 
-from .helper import get_boot_stats, print_simple_list, print_table_stats
+from .helper import (
+    get_boot_stats,
+    print_simple_list,
+    print_table_stats,
+    print_validation_json,
+    validation_rows_to_json,
+)
 
 
 @click.command(
@@ -75,6 +83,19 @@ Examples:
     default=False,
     help="Display results in table format",
 )
+@click.option(
+    "--json",
+    "use_json",
+    is_flag=True,
+    default=False,
+    help="Print validation results as JSON",
+)
+@click.option(
+    "--fail-on-mismatch",
+    is_flag=True,
+    default=False,
+    help="Exit with status 1 when validation finds mismatches",
+)
 @click.pass_context
 def boots(
     ctx,
@@ -89,33 +110,49 @@ def boots(
     days,
     verbose,
     table_output,
+    use_json,
+    fail_on_mismatch,
 ):
     final_stats = []
-    print("Fetching boot information...")
-    if all_checkouts:
-        if giturl or branch or commit:
-            raise click.UsageError(
-                "Cannot use --all-checkouts with --giturl, --branch, or --commit"
+    stdout = sys.stdout
+    if use_json:
+        sys.stdout = sys.stderr
+    try:
+        if not use_json:
+            print("Fetching boot information...")
+        if all_checkouts:
+            if giturl or branch or commit:
+                raise click.UsageError(
+                    "Cannot use --all-checkouts with --giturl, --branch, or --commit"
+                )
+            trees_list = ctx.invoke(trees, origin=origin, days=days, verbose=False)
+            for tree in trees_list:
+                giturl = tree["git_repository_url"]
+                branch = tree["git_repository_branch"]
+                commit = tree["git_commit_hash"]
+                tree_name = tree["tree_name"]
+                stats = get_boot_stats(
+                    ctx, giturl, branch, commit, tree_name, verbose, arch, use_json
+                )
+                if stats:
+                    final_stats.append(stats)
+        else:
+            giturl, branch, commit = set_giturl_branch_commit(
+                origin, giturl, branch, commit, latest, git_folder
             )
-        trees_list = ctx.invoke(trees, origin=origin, days=days, verbose=False)
-        for tree in trees_list:
-            giturl = tree["git_repository_url"]
-            branch = tree["git_repository_branch"]
-            commit = tree["git_commit_hash"]
-            tree_name = tree["tree_name"]
+            tree_name = get_tree_name(origin, giturl, branch)
             stats = get_boot_stats(
-                ctx, giturl, branch, commit, tree_name, verbose, arch
+                ctx, giturl, branch, commit, tree_name, verbose, arch, use_json
             )
             if stats:
                 final_stats.append(stats)
-    else:
-        giturl, branch, commit = set_giturl_branch_commit(
-            origin, giturl, branch, commit, latest, git_folder
-        )
-        tree_name = get_tree_name(origin, giturl, branch)
-        stats = get_boot_stats(ctx, giturl, branch, commit, tree_name, verbose, arch)
-        if stats:
-            final_stats.append(stats)
+    finally:
+        sys.stdout = stdout
+    if use_json:
+        report = print_validation_json("boots", final_stats, False, origin, days, arch)
+        if fail_on_mismatch and not report["summary"]["ok"]:
+            ctx.exit(1)
+        return
     if final_stats:
         headers = [
             "tree/branch",
@@ -132,3 +169,9 @@ def boots(
             print_table_stats(final_stats, headers, max_col_width, table_fmt)
         else:
             print_simple_list(final_stats, "boots", False)
+    if fail_on_mismatch:
+        report = validation_rows_to_json(
+            "boots", final_stats, False, origin, days, arch
+        )
+        if not report["summary"]["ok"]:
+            ctx.exit(1)

--- a/kcidev/subcommands/maestro/validate/builds.py
+++ b/kcidev/subcommands/maestro/validate/builds.py
@@ -1,3 +1,5 @@
+import sys
+
 import click
 
 from kcidev.libs.git_repo import get_tree_name, set_giturl_branch_commit
@@ -8,6 +10,8 @@ from .helper import (
     get_builds_history_stats,
     print_simple_list,
     print_table_stats,
+    print_validation_json,
+    validation_rows_to_json,
 )
 
 
@@ -93,6 +97,19 @@ Examples:
     default=False,
     help="Display results in table format instead of simple list",
 )
+@click.option(
+    "--json",
+    "use_json",
+    is_flag=True,
+    default=False,
+    help="Print validation results as JSON",
+)
+@click.option(
+    "--fail-on-mismatch",
+    is_flag=True,
+    default=False,
+    help="Exit with status 1 when validation finds mismatches",
+)
 @click.pass_context
 def builds(
     ctx,
@@ -108,50 +125,68 @@ def builds(
     history,
     verbose,
     table_output,
+    use_json,
+    fail_on_mismatch,
 ):
     final_stats = []
-    print("Fetching build information...")
-    if all_checkouts:
-        if giturl or branch or commit:
-            raise click.UsageError(
-                "Cannot use --all-checkouts with --giturl, --branch, or --commit"
+    stdout = sys.stdout
+    if use_json:
+        sys.stdout = sys.stderr
+    try:
+        if not use_json:
+            print("Fetching build information...")
+        if all_checkouts:
+            if giturl or branch or commit:
+                raise click.UsageError(
+                    "Cannot use --all-checkouts with --giturl, --branch, or --commit"
+                )
+            if history:
+                trees_list = ctx.invoke(trees, origin=origin, days=days, verbose=False)
+                for tree in trees_list:
+                    giturl = tree["git_repository_url"]
+                    branch = tree["git_repository_branch"]
+                    tree_name = tree["tree_name"]
+                    stats = get_builds_history_stats(
+                        ctx, giturl, branch, tree_name, arch, days, verbose, use_json
+                    )
+                    if stats:
+                        final_stats.extend(stats)
+            else:
+                trees_list = ctx.invoke(trees, origin=origin, days=days, verbose=False)
+                for tree in trees_list:
+                    giturl = tree["git_repository_url"]
+                    branch = tree["git_repository_branch"]
+                    commit = tree["git_commit_hash"]
+                    tree_name = tree["tree_name"]
+                    stats = get_build_stats(
+                        ctx, giturl, branch, commit, tree_name, verbose, arch, use_json
+                    )
+                    if stats:
+                        final_stats.append(stats)
+        elif history:
+            tree_name = get_tree_name(origin, giturl, branch)
+            final_stats = get_builds_history_stats(
+                ctx, giturl, branch, tree_name, arch, days, verbose, use_json
             )
-        if history:
-            trees_list = ctx.invoke(trees, origin=origin, days=days, verbose=False)
-            for tree in trees_list:
-                giturl = tree["git_repository_url"]
-                branch = tree["git_repository_branch"]
-                tree_name = tree["tree_name"]
-                stats = get_builds_history_stats(
-                    ctx, giturl, branch, tree_name, arch, days, verbose
-                )
-                if stats:
-                    final_stats.extend(stats)
         else:
-            trees_list = ctx.invoke(trees, origin=origin, days=days, verbose=False)
-            for tree in trees_list:
-                giturl = tree["git_repository_url"]
-                branch = tree["git_repository_branch"]
-                commit = tree["git_commit_hash"]
-                tree_name = tree["tree_name"]
-                stats = get_build_stats(
-                    ctx, giturl, branch, commit, tree_name, verbose, arch
-                )
-                if stats:
-                    final_stats.append(stats)
-    elif history:
-        tree_name = get_tree_name(origin, giturl, branch)
-        final_stats = get_builds_history_stats(
-            ctx, giturl, branch, tree_name, arch, days, verbose
+            giturl, branch, commit = set_giturl_branch_commit(
+                origin, giturl, branch, commit, latest, git_folder
+            )
+            tree_name = get_tree_name(origin, giturl, branch)
+            stats = get_build_stats(
+                ctx, giturl, branch, commit, tree_name, verbose, arch, use_json
+            )
+            if stats:
+                final_stats.append(stats)
+    finally:
+        sys.stdout = stdout
+    if use_json:
+        report = print_validation_json(
+            "builds", final_stats, history, origin, days, arch
         )
-    else:
-        giturl, branch, commit = set_giturl_branch_commit(
-            origin, giturl, branch, commit, latest, git_folder
-        )
-        tree_name = get_tree_name(origin, giturl, branch)
-        stats = get_build_stats(ctx, giturl, branch, commit, tree_name, verbose, arch)
-        if stats:
-            final_stats.append(stats)
+        if fail_on_mismatch and not report["summary"]["ok"]:
+            ctx.exit(1)
+        return
     if final_stats:
         if history:
             headers = [
@@ -180,3 +215,9 @@ def builds(
             print_table_stats(final_stats, headers, max_col_width, table_fmt)
         else:
             print_simple_list(final_stats, "builds", history)
+    if fail_on_mismatch:
+        report = validation_rows_to_json(
+            "builds", final_stats, history, origin, days, arch
+        )
+        if not report["summary"]["ok"]:
+            ctx.exit(1)

--- a/kcidev/subcommands/maestro/validate/helper.py
+++ b/kcidev/subcommands/maestro/validate/helper.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import json
 from datetime import datetime, timedelta
 
 import click
@@ -10,7 +11,7 @@ from kcidev.subcommands.maestro.results import results
 from kcidev.subcommands.results import boots, builds
 
 
-def get_builds(ctx, giturl, branch, commit, arch):
+def get_builds(ctx, giturl, branch, commit, arch, raise_errors=False):
     """Get builds matching git URL, branch, and commit
     Architecture can also be provided for filtering"""
     maestro_builds = []
@@ -42,12 +43,16 @@ def get_builds(ctx, giturl, branch, commit, arch):
             arch=arch,
         )
     except click.Abort:
+        if raise_errors:
+            raise
         kci_msg_red(f"{branch}/{commit}: Aborted while fetching dashboard builds")
         return maestro_builds, None
     except click.ClickException as e:
-        kci_msg_red(f"{branch}/{commit}: {e.message}")
         if "No builds available" in e.message:
             return maestro_builds, []
+        if raise_errors:
+            raise
+        kci_msg_red(f"{branch}/{commit}: {e.message}")
         return maestro_builds, None
     return maestro_builds, dashboard_builds
 
@@ -113,9 +118,13 @@ def validate_build_status(maestro_builds, dashboard_builds):
     return builds_with_status_mismatch
 
 
-def get_build_stats(ctx, giturl, branch, commit, tree_name, verbose, arch):
+def get_build_stats(
+    ctx, giturl, branch, commit, tree_name, verbose, arch, raise_errors=False
+):
     """Get build stats"""
-    maestro_builds, dashboard_builds = get_builds(ctx, giturl, branch, commit, arch)
+    maestro_builds, dashboard_builds = get_builds(
+        ctx, giturl, branch, commit, arch, raise_errors
+    )
     if dashboard_builds is None:
         return []
     missing_build_ids = []
@@ -127,7 +136,11 @@ def get_build_stats(ctx, giturl, branch, commit, tree_name, verbose, arch):
     builds_with_status_mismatch = validate_build_status(
         maestro_builds, dashboard_builds
     )
-    if missing_build_ids or builds_with_status_mismatch:
+    if (
+        len(dashboard_builds) != len(maestro_builds)
+        or missing_build_ids
+        or builds_with_status_mismatch
+    ):
         summary_flag = "❌"
     stats = [
         f"{tree_name}/{branch}",
@@ -174,9 +187,13 @@ def print_simple_list(data, item_type, history=False):
 
         for row in data:
             try:
-                tree_branch, commit, comparison, missing_ids, mismatched_ids = (
-                    extract_validation_data(row)
-                )
+                (
+                    tree_branch,
+                    commit,
+                    comparison,
+                    missing_ids,
+                    mismatched_ids,
+                ) = extract_validation_data(row)
             except ValueError:
                 continue
             tree_groups[tree_branch].append(
@@ -210,9 +227,13 @@ def print_simple_list(data, item_type, history=False):
         # For non-history mode, show each individual result
         for row in data:
             try:
-                tree_branch, commit, comparison, missing_ids, mismatched_ids = (
-                    extract_validation_data(row)
-                )
+                (
+                    tree_branch,
+                    commit,
+                    comparison,
+                    missing_ids,
+                    mismatched_ids,
+                ) = extract_validation_data(row)
             except ValueError:
                 continue
             kci_msg_bold(f"• {tree_branch}: ", nl=False)
@@ -228,6 +249,52 @@ def print_simple_list(data, item_type, history=False):
                 for id in mismatched_ids:
                     kci_msg(f"  - https://api.kernelci.org/viewer?node_id={id}")
             kci_msg("")
+
+
+def validation_rows_to_json(kind, rows, history, origin, days, arch):
+    """Convert validation stats rows to the public JSON report format."""
+    results = []
+    for row in rows:
+        missing_ids = row[5] or []
+        status_mismatch_ids = row[6] or []
+        ok = row[2] == row[3] and row[4] == "✅" and not missing_ids
+        ok = ok and not status_mismatch_ids
+        results.append(
+            {
+                "tree_branch": row[0],
+                "commit": row[1],
+                "maestro_count": row[2],
+                "dashboard_count": row[3],
+                "ok": ok,
+                "missing_ids": missing_ids,
+                "status_mismatch_ids": status_mismatch_ids,
+            }
+        )
+
+    return {
+        "kind": kind,
+        "history": history,
+        "origin": origin,
+        "days": days,
+        "arch": arch,
+        "summary": {
+            "checked": len(results),
+            "failed": sum(not result["ok"] for result in results),
+            "missing": sum(len(result["missing_ids"]) for result in results),
+            "status_mismatches": sum(
+                len(result["status_mismatch_ids"]) for result in results
+            ),
+            "ok": all(result["ok"] for result in results),
+        },
+        "results": results,
+    }
+
+
+def print_validation_json(kind, rows, history, origin, days, arch):
+    """Print a single JSON validation report to stdout."""
+    report = validation_rows_to_json(kind, rows, history, origin, days, arch)
+    click.echo(json.dumps(report))
+    return report
 
 
 def validate_boot_status(maestro_boots, dashboard_boots):
@@ -281,7 +348,7 @@ def validate_boot_status(maestro_boots, dashboard_boots):
     return boots_with_status_mismatch
 
 
-def get_boots(ctx, giturl, branch, commit, arch):
+def get_boots(ctx, giturl, branch, commit, arch, raise_errors=False):
     """Get boots matching git URL, branch, and commit"""
     maestro_boots = []
     dashboard_boots = []
@@ -313,19 +380,27 @@ def get_boots(ctx, giturl, branch, commit, arch):
             boot_origin="maestro",
         )
     except click.Abort:
+        if raise_errors:
+            raise
         kci_msg_red(f"{branch}/{commit}: Aborted while fetching dashboard boots")
         return maestro_boots, None
     except click.ClickException as e:
-        kci_msg_red(f"{branch}/{commit}: {e.message}")
         if "No boots available" in e.message:
             return maestro_boots, []
+        if raise_errors:
+            raise
+        kci_msg_red(f"{branch}/{commit}: {e.message}")
         return maestro_boots, None
     return maestro_boots, dashboard_boots
 
 
-def get_boot_stats(ctx, giturl, branch, commit, tree_name, verbose, arch):
+def get_boot_stats(
+    ctx, giturl, branch, commit, tree_name, verbose, arch, raise_errors=False
+):
     """Get boot stats"""
-    maestro_boots, dashboard_boots = get_boots(ctx, giturl, branch, commit, arch)
+    maestro_boots, dashboard_boots = get_boots(
+        ctx, giturl, branch, commit, arch, raise_errors
+    )
     if dashboard_boots is None:
         return []
     missing_boot_ids = []
@@ -335,7 +410,11 @@ def get_boot_stats(ctx, giturl, branch, commit, tree_name, verbose, arch):
             maestro_boots, dashboard_boots, "boot", verbose
         )
     boots_with_status_mismatch = validate_boot_status(maestro_boots, dashboard_boots)
-    if missing_boot_ids or boots_with_status_mismatch:
+    if (
+        len(dashboard_boots) != len(maestro_boots)
+        or missing_boot_ids
+        or boots_with_status_mismatch
+    ):
         summary_flag = "❌"
     stats = [
         f"{tree_name}/{branch}",
@@ -349,21 +428,30 @@ def get_boot_stats(ctx, giturl, branch, commit, tree_name, verbose, arch):
     return stats
 
 
-def get_builds_history_stats(ctx, giturl, branch, tree_name, arch, days, verbose):
+def get_builds_history_stats(
+    ctx, giturl, branch, tree_name, arch, days, verbose, raise_errors=False
+):
     checkouts = get_checkouts(ctx, giturl, branch, days)
     final_stats = []
-    builds_history = get_builds_history(ctx, checkouts, arch)
+    builds_history = get_builds_history(ctx, checkouts, arch, raise_errors)
     for b in builds_history:
         missing_build_ids = find_missing_items(b[1], b[2], "build", verbose)
         total_maestro_builds = len(b[1])
         total_dashboard_builds = len(b[2])
         mismatched_ids = validate_build_status(b[1], b[2])
+        summary_flag = (
+            "✅"
+            if total_maestro_builds == total_dashboard_builds
+            and not missing_build_ids
+            and not mismatched_ids
+            else "❌"
+        )
         stats = [
             f"{tree_name}/{branch}",
             b[0],
             total_maestro_builds,
             total_dashboard_builds,
-            "✅" if total_maestro_builds == total_dashboard_builds else "❌",
+            summary_flag,
             missing_build_ids,
             mismatched_ids,
         ]
@@ -393,7 +481,7 @@ def get_checkouts(ctx, giturl, branch, days):
     return checkouts
 
 
-def get_builds_history(ctx, checkouts, arch):
+def get_builds_history(ctx, checkouts, arch, raise_errors=False):
     """Get builds from maestro and dashboard for provided checkouts"""
     builds_history = []
     for c in checkouts:
@@ -427,9 +515,14 @@ def get_builds_history(ctx, checkouts, arch):
             )
             builds_history.append([commit, maestro_builds, dashboard_builds])
         except click.Abort:
+            if raise_errors:
+                raise
             kci_msg_red(f"{branch}/{commit}: Aborted while fetching dashboard builds")
         except click.ClickException as e:
-            kci_msg_red(f"{branch}/{commit}: {e.message}")
             if "No builds available" in e.message:
                 builds_history.append([commit, maestro_builds, []])
+                continue
+            if raise_errors:
+                raise
+            kci_msg_red(f"{branch}/{commit}: {e.message}")
     return builds_history

--- a/tests/test_maestro_validate_json.py
+++ b/tests/test_maestro_validate_json.py
@@ -1,0 +1,321 @@
+import importlib
+import json
+
+import click
+from click.testing import CliRunner
+
+from kcidev.subcommands.maestro.validate.helper import validation_rows_to_json
+
+COMMIT = "a" * 40
+
+
+def _stdout(result):
+    return getattr(result, "stdout", result.output)
+
+
+def _build_row(
+    maestro_count=1,
+    dashboard_count=1,
+    summary_flag="✅",
+    missing_ids=None,
+    status_mismatch_ids=None,
+):
+    return [
+        "mainline/master",
+        COMMIT,
+        maestro_count,
+        dashboard_count,
+        summary_flag,
+        missing_ids or [],
+        status_mismatch_ids or [],
+    ]
+
+
+def _patch_builds_command(monkeypatch, stats):
+    builds_module = importlib.import_module(
+        "kcidev.subcommands.maestro.validate.builds"
+    )
+    monkeypatch.setattr(
+        builds_module,
+        "set_giturl_branch_commit",
+        lambda origin, giturl, branch, commit, latest, git_folder: (
+            giturl,
+            branch,
+            commit,
+        ),
+    )
+    monkeypatch.setattr(
+        builds_module,
+        "get_tree_name",
+        lambda origin, giturl, branch: "mainline",
+    )
+    monkeypatch.setattr(
+        builds_module,
+        "get_build_stats",
+        lambda ctx, giturl, branch, commit, tree_name, verbose, arch, raise_errors=False: stats,
+    )
+    return builds_module.builds
+
+
+def _patch_boots_command(monkeypatch, stats):
+    boots_module = importlib.import_module("kcidev.subcommands.maestro.validate.boots")
+    monkeypatch.setattr(
+        boots_module,
+        "set_giturl_branch_commit",
+        lambda origin, giturl, branch, commit, latest, git_folder: (
+            giturl,
+            branch,
+            commit,
+        ),
+    )
+    monkeypatch.setattr(
+        boots_module,
+        "get_tree_name",
+        lambda origin, giturl, branch: "mainline",
+    )
+    monkeypatch.setattr(
+        boots_module,
+        "get_boot_stats",
+        lambda ctx, giturl, branch, commit, tree_name, verbose, arch, raise_errors=False: stats,
+    )
+    return boots_module.boots
+
+
+def _json_args():
+    return [
+        "--giturl",
+        "https://example.com/linux.git",
+        "--branch",
+        "master",
+        "--commit",
+        COMMIT,
+        "--days",
+        "1",
+        "--json",
+    ]
+
+
+def test_builds_json_emits_valid_json(monkeypatch):
+    command = _patch_builds_command(monkeypatch, _build_row())
+    result = CliRunner().invoke(command, _json_args())
+
+    assert result.exit_code == 0
+    report = json.loads(_stdout(result))
+    assert report["kind"] == "builds"
+    assert report["history"] is False
+    assert report["summary"]["ok"] is True
+    assert report["results"][0]["commit"] == COMMIT
+
+
+def test_boots_json_emits_valid_json(monkeypatch):
+    command = _patch_boots_command(monkeypatch, _build_row())
+    result = CliRunner().invoke(command, _json_args())
+
+    assert result.exit_code == 0
+    report = json.loads(_stdout(result))
+    assert report["kind"] == "boots"
+    assert report["history"] is False
+    assert report["summary"]["ok"] is True
+    assert report["results"][0]["tree_branch"] == "mainline/master"
+
+
+def test_json_mode_does_not_write_progress_to_stdout(monkeypatch):
+    command = _patch_builds_command(monkeypatch, _build_row())
+    result = CliRunner().invoke(command, _json_args())
+
+    assert result.exit_code == 0
+    assert "Fetching build information" not in _stdout(result)
+    json.loads(_stdout(result))
+
+
+def test_json_mode_redirects_internal_stdout(monkeypatch):
+    builds_module = importlib.import_module(
+        "kcidev.subcommands.maestro.validate.builds"
+    )
+    monkeypatch.setattr(
+        builds_module,
+        "set_giturl_branch_commit",
+        lambda origin, giturl, branch, commit, latest, git_folder: (
+            giturl,
+            branch,
+            commit,
+        ),
+    )
+    monkeypatch.setattr(
+        builds_module,
+        "get_tree_name",
+        lambda origin, giturl, branch: "mainline",
+    )
+
+    def get_stats(*args, **kwargs):
+        print("internal progress")
+        return _build_row()
+
+    monkeypatch.setattr(builds_module, "get_build_stats", get_stats)
+
+    result = CliRunner().invoke(builds_module.builds, _json_args())
+
+    assert result.exit_code == 0
+    assert "internal progress" not in _stdout(result)
+    json.loads(_stdout(result))
+
+
+def test_missing_ids_make_summary_not_ok():
+    report = validation_rows_to_json(
+        "builds",
+        [_build_row(2, 1, "❌", missing_ids=["b-1"])],
+        False,
+        "maestro",
+        1,
+        None,
+    )
+
+    assert report["summary"]["ok"] is False
+    assert report["summary"]["failed"] == 1
+    assert report["summary"]["missing"] == 1
+    assert report["results"][0]["ok"] is False
+
+
+def test_status_mismatches_make_summary_not_ok():
+    report = validation_rows_to_json(
+        "boots",
+        [_build_row(status_mismatch_ids=["job-1"])],
+        False,
+        "maestro",
+        1,
+        None,
+    )
+
+    assert report["summary"]["ok"] is False
+    assert report["summary"]["failed"] == 1
+    assert report["summary"]["status_mismatches"] == 1
+    assert report["results"][0]["ok"] is False
+
+
+def test_build_history_count_mismatch_make_summary_not_ok():
+    report = validation_rows_to_json(
+        "builds",
+        [_build_row(2, 1, "❌")],
+        True,
+        "maestro",
+        1,
+        None,
+    )
+
+    assert report["history"] is True
+    assert report["summary"]["ok"] is False
+    assert report["summary"]["failed"] == 1
+    assert report["results"][0]["ok"] is False
+
+
+def test_json_mismatches_still_exit_zero(monkeypatch):
+    command = _patch_builds_command(
+        monkeypatch, _build_row(2, 1, "❌", missing_ids=["b-1"])
+    )
+    result = CliRunner().invoke(command, _json_args())
+
+    assert result.exit_code == 0
+    assert json.loads(_stdout(result))["summary"]["ok"] is False
+
+
+def test_json_runtime_failures_exit_nonzero(monkeypatch):
+    builds_module = importlib.import_module(
+        "kcidev.subcommands.maestro.validate.builds"
+    )
+    monkeypatch.setattr(
+        builds_module,
+        "set_giturl_branch_commit",
+        lambda origin, giturl, branch, commit, latest, git_folder: (
+            giturl,
+            branch,
+            commit,
+        ),
+    )
+    monkeypatch.setattr(
+        builds_module,
+        "get_tree_name",
+        lambda origin, giturl, branch: "mainline",
+    )
+
+    def fail(*args, **kwargs):
+        raise click.ClickException("API unavailable")
+
+    monkeypatch.setattr(builds_module, "get_build_stats", fail)
+
+    result = CliRunner().invoke(builds_module.builds, _json_args())
+
+    assert result.exit_code != 0
+
+
+def test_fail_on_mismatch_no_mismatches_exits_zero(monkeypatch):
+    command = _patch_builds_command(monkeypatch, _build_row())
+    args = _json_args()[:-1] + ["--fail-on-mismatch"]
+
+    result = CliRunner().invoke(command, args)
+
+    assert result.exit_code == 0
+
+
+def test_fail_on_mismatch_missing_ids_exit_one(monkeypatch):
+    command = _patch_builds_command(
+        monkeypatch, _build_row(2, 1, "❌", missing_ids=["b-1"])
+    )
+    args = _json_args()[:-1] + ["--fail-on-mismatch"]
+
+    result = CliRunner().invoke(command, args)
+
+    assert result.exit_code == 1
+
+
+def test_fail_on_mismatch_status_mismatches_exit_one(monkeypatch):
+    command = _patch_boots_command(
+        monkeypatch, _build_row(status_mismatch_ids=["job-1"])
+    )
+    args = _json_args()[:-1] + ["--fail-on-mismatch"]
+
+    result = CliRunner().invoke(command, args)
+
+    assert result.exit_code == 1
+
+
+def test_fail_on_mismatch_build_history_count_mismatch_exit_one(monkeypatch):
+    builds_module = importlib.import_module(
+        "kcidev.subcommands.maestro.validate.builds"
+    )
+    monkeypatch.setattr(
+        builds_module,
+        "get_tree_name",
+        lambda origin, giturl, branch: "mainline",
+    )
+    monkeypatch.setattr(
+        builds_module,
+        "get_builds_history_stats",
+        lambda ctx, giturl, branch, tree_name, arch, days, verbose, raise_errors=False: [
+            _build_row(2, 1, "❌")
+        ],
+    )
+    args = [
+        "--giturl",
+        "https://example.com/linux.git",
+        "--branch",
+        "master",
+        "--days",
+        "1",
+        "--history",
+        "--fail-on-mismatch",
+    ]
+
+    result = CliRunner().invoke(builds_module.builds, args)
+
+    assert result.exit_code == 1
+
+
+def test_mismatch_without_fail_on_mismatch_still_exits_zero(monkeypatch):
+    command = _patch_builds_command(
+        monkeypatch, _build_row(2, 1, "❌", missing_ids=["b-1"])
+    )
+    args = _json_args()[:-1]
+
+    result = CliRunner().invoke(command, args)
+
+    assert result.exit_code == 0


### PR DESCRIPTION
Add machine-readable JSON output to kci-dev maestro validate builds and boots so automation can verify Maestro and Dashboard consistency without parsing human-readable CLI output.

This supports kernelci/kernelci-pipeline#1125, Validate maestro build results consistency. KernelCI users need stable build and boot counts with no silent result loss, missing records, or mismapped statuses on the dashboard. The structured summary lets daily validation jobs compare Dashboard API data,Maestro API data, and recent checkout expectations, then decide policy from summary.ok.

The JSON mode emits a single JSON object on stdout, redirects incidental progress output away from stdout, and exits 0 for successful validation runs even when mismatches are reported.

Runtime/API errors still exit nonzero. An optional --fail-on-mismatch flag is also added for workflows that want the command itself to fail when validation finds inconsistencies.

Tests cover JSON output for builds, boots, and build history mismatch cases; stdout cleanliness; missing ID and status mismatch summaries; mismatch exit behavior; and runtime failure handling.