### PR TITLE
fix: Fix dashboard retry backoff import

### DIFF
--- a/kcidev/libs/dashboard.py
+++ b/kcidev/libs/dashboard.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import time
 import urllib
 from datetime import datetime, timedelta
 from functools import wraps

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,21 @@
+from unittest.mock import Mock
+
+from kcidev.libs import dashboard
+
+
+def test_dashboard_api_fetch_retries_retryable_status(monkeypatch):
+    retry_response = Mock(status_code=504)
+    success_response = Mock(status_code=200)
+    success_response.json.return_value = {"ok": True}
+
+    get = Mock(side_effect=[retry_response, success_response])
+    sleep = Mock()
+
+    monkeypatch.setattr(dashboard.kcidev_session, "get", get)
+    monkeypatch.setattr(dashboard.time, "sleep", sleep)
+
+    result = dashboard.dashboard_api_fetch("hardware/", {}, False, max_retries=1)
+
+    assert result == {"ok": True}
+    assert get.call_count == 2
+    sleep.assert_called_once_with(2)


### PR DESCRIPTION
Fix the NameError i spotted when retry backoff calls time.sleep. Import time for dashboard retry backoff.
Cover retryable 504 responses with a focused unit test.