### PR TITLE
mcp: size tool responses for context-limited clients

### DIFF
--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -48,3 +48,9 @@ trust.
 Tools that change state (`retry_job`, `trigger_checkout`) are annotated
 as non-read-only so MCP clients can ask for confirmation before calling
 them.
+
+Responses are sized for context-limited clients: `get_summary` returns
+compact aggregates unless `detail=true` is passed, and the list tools
+paginate (default `limit` of 20) and accept a `fields` list to return
+only the named keys per entry. Prefer `status`/`arch` filters, small
+limits and field projection when exploring large trees.

--- a/kcidev/mcp/tools_dashboard.py
+++ b/kcidev/mcp/tools_dashboard.py
@@ -8,14 +8,17 @@ from kcidev.mcp.errors import tool_errors
 _client = KernelCIClient()
 
 
-def _page(data, key, status, limit, offset):
+def _page(data, key, status, limit, offset, fields=None):
     items = data[key] if isinstance(data, dict) else data
     total = len(items)
     if status:
         status_filter = StatusFilter(status)
         items = [item for item in items if status_filter.matches(item)]
+    page = items[offset : offset + limit]
+    if fields:
+        page = [{k: item[k] for k in fields if k in item} for item in page]
     return {
-        key: items[offset : offset + limit],
+        key: page,
         "total": total,
         "matched": len(items),
         "limit": limit,
@@ -34,6 +37,9 @@ def list_trees(origin: str = "maestro", days: int = 7):
     return _client.get_tree_list(origin, days)
 
 
+_COMPACT_SUMMARY_KEYS = ("status", "architectures", "issues", "failed_platforms")
+
+
 @tool_errors
 def get_summary(
     giturl: str,
@@ -41,13 +47,28 @@ def get_summary(
     commit: str,
     origin: str = "maestro",
     arch: str | None = None,
+    detail: bool = False,
 ):
     """Get the build/boot/test summary for one commit of a tree.
 
-    Returns aggregated pass/fail/inconclusive counts. Use list_trees to
-    find giturl, branch and commit values.
+    Returns compact aggregated status counts by default; pass
+    detail=True for the full dashboard summary (much larger). Use
+    list_trees to find giturl, branch and commit values.
     """
-    return _client.get_summary(origin, giturl, branch, commit, arch)
+    data = _client.get_summary(origin, giturl, branch, commit, arch)
+    if detail or not isinstance(data, dict):
+        return data
+    summary = data.get("summary")
+    if not isinstance(summary, dict):
+        return data
+    return {
+        "common": data.get("common"),
+        "summary": {
+            section: {k: v for k, v in counts.items() if k in _COMPACT_SUMMARY_KEYS}
+            for section, counts in summary.items()
+            if isinstance(counts, dict)
+        },
+    }
 
 
 @tool_errors
@@ -87,21 +108,23 @@ def list_builds(
     start_date: str | None = None,
     end_date: str | None = None,
     status: str | None = None,
-    limit: int = 100,
+    limit: int = 20,
     offset: int = 0,
+    fields: list[str] | None = None,
 ):
     """List kernel builds for one commit of a tree.
 
     Optional filters: arch (e.g. 'arm64'), tree name, ISO date range, and
     status ('pass', 'fail' or 'inconclusive'). Results are paginated with
     limit/offset; the response carries 'total' (before status filtering)
-    and 'matched' counts so you know whether to fetch further pages.
+    and 'matched' counts so you know whether to fetch further pages;
+    fields projects each entry to only those keys.
     Returns build entries with ids usable with get_build.
     """
     data = _client.get_builds(
         origin, giturl, branch, commit, arch, tree, start_date, end_date
     )
-    return _page(data, "builds", status, limit, offset)
+    return _page(data, "builds", status, limit, offset, fields)
 
 
 @tool_errors
@@ -116,21 +139,23 @@ def list_boots(
     end_date: str | None = None,
     boot_origin: str | None = None,
     status: str | None = None,
-    limit: int = 100,
+    limit: int = 20,
     offset: int = 0,
+    fields: list[str] | None = None,
 ):
     """List boot test results for one commit of a tree.
 
     Optional filters: arch, tree name, ISO date range, boot origin, and
     status ('pass', 'fail' or 'inconclusive'). Results are paginated with
     limit/offset; the response carries 'total' (before status filtering)
-    and 'matched' counts so you know whether to fetch further pages.
+    and 'matched' counts so you know whether to fetch further pages;
+    fields projects each entry to only those keys.
     Returns boot entries with ids usable with get_test.
     """
     data = _client.get_boots(
         origin, giturl, branch, commit, arch, tree, start_date, end_date, boot_origin
     )
-    return _page(data, "boots", status, limit, offset)
+    return _page(data, "boots", status, limit, offset, fields)
 
 
 @tool_errors
@@ -144,8 +169,9 @@ def list_tests(
     start_date: str | None = None,
     end_date: str | None = None,
     status: str | None = None,
-    limit: int = 100,
+    limit: int = 20,
     offset: int = 0,
+    fields: list[str] | None = None,
 ):
     """List test results for one commit of a tree.
 
@@ -153,13 +179,14 @@ def list_tests(
     'fail' or 'inconclusive'). A full commit can carry tens of thousands
     of tests, so filter by status and paginate with limit/offset; the
     response carries 'total' (before status filtering) and 'matched'
-    counts so you know whether to fetch further pages.
+    counts so you know whether to fetch further pages; fields projects
+    each entry to only those keys.
     Returns test entries with ids usable with get_test.
     """
     data = _client.get_tests(
         origin, giturl, branch, commit, arch, tree, start_date, end_date
     )
-    return _page(data, "tests", status, limit, offset)
+    return _page(data, "tests", status, limit, offset, fields)
 
 
 @tool_errors
@@ -224,17 +251,18 @@ def get_issue_builds(
     issue_id: str,
     origin: str = "maestro",
     status: str | None = None,
-    limit: int = 100,
+    limit: int = 20,
     offset: int = 0,
+    fields: list[str] | None = None,
 ):
     """List builds affected by a known issue.
 
     Optional status filter ('pass', 'fail' or 'inconclusive') and
     limit/offset pagination; the response carries 'total' and 'matched'
-    counts.
+    counts; fields projects each entry to only those keys.
     """
     data = _client.get_issue_builds(issue_id, origin)
-    return _page(data, "builds", status, limit, offset)
+    return _page(data, "builds", status, limit, offset, fields)
 
 
 @tool_errors
@@ -242,17 +270,18 @@ def get_issue_tests(
     issue_id: str,
     origin: str = "maestro",
     status: str | None = None,
-    limit: int = 100,
+    limit: int = 20,
     offset: int = 0,
+    fields: list[str] | None = None,
 ):
     """List tests affected by a known issue.
 
     Optional status filter ('pass', 'fail' or 'inconclusive') and
     limit/offset pagination; the response carries 'total' and 'matched'
-    counts.
+    counts; fields projects each entry to only those keys.
     """
     data = _client.get_issue_tests(issue_id, origin)
-    return _page(data, "tests", status, limit, offset)
+    return _page(data, "tests", status, limit, offset, fields)
 
 
 READ_ONLY_TOOLS = (

--- a/kcidev/mcp/tools_maestro.py
+++ b/kcidev/mcp/tools_maestro.py
@@ -27,7 +27,10 @@ def register_tools(server, client, api_url, pipeline_url, token):
         @server.tool(annotations=read_only)
         @tool_errors
         def list_nodes(
-            filters: list[str] | None = None, limit: int = 50, offset: int = 0
+            filters: list[str] | None = None,
+            limit: int = 50,
+            offset: int = 0,
+            fields: list[str] | None = None,
         ):
             """List Maestro nodes, oldest first, optionally filtered.
 
@@ -38,9 +41,13 @@ def register_tools(server, client, api_url, pipeline_url, token):
             are returned oldest first, so to reach recent nodes window the
             query with a filter such as 'created__gt=2026-07-01' rather
             than paginating from the start. Use limit and offset to
-            paginate within the window.
+            paginate within the window; full nodes are large, so use
+            fields to project each node to only those keys.
             """
-            return client.get_nodes(limit=limit, offset=offset, filters=filters or [])
+            nodes = client.get_nodes(limit=limit, offset=offset, filters=filters or [])
+            if fields:
+                return [{k: n[k] for k in fields if k in n} for n in nodes]
+            return nodes
 
     if pipeline_url and token:
 

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -153,3 +153,23 @@ def test_retry_job_failure_returns_tool_error(monkeypatch):
     result = _call_tool(create_server(CFG, "test"), "retry_job", {"node_id": "n1"})
     assert result.isError is True
     assert "retry failed" in result.content[0].text
+
+
+def test_list_nodes_projects_fields(monkeypatch):
+    from kcidev.libs import maestro_common
+
+    response = Mock(status_code=200)
+    response.json.return_value = [
+        {"id": "n1", "name": "checkout", "state": "done", "commit_message": "huge"}
+    ]
+    monkeypatch.setattr(
+        maestro_common.kcidev_session, "get", Mock(return_value=response)
+    )
+    result = _call_tool(
+        create_server(CFG, "test"),
+        "list_nodes",
+        {"fields": ["id", "state"]},
+    )
+    assert result.isError is False
+    assert '"commit_message"' not in result.content[0].text
+    assert '"n1"' in result.content[0].text

--- a/tests/test_mcp_tools_dashboard.py
+++ b/tests/test_mcp_tools_dashboard.py
@@ -103,7 +103,7 @@ def test_list_tests_default_limit_bounds_response(monkeypatch):
     )
     assert result["total"] == 300
     assert result["matched"] == 300
-    assert len(result["tests"]) == 100
+    assert len(result["tests"]) == 20
 
 
 def test_get_issue_builds_wraps_bare_list(monkeypatch):
@@ -151,3 +151,66 @@ def test_list_commits_not_found_includes_guidance(monkeypatch):
             branch="master",
             commit="deadbeef",
         )
+
+
+def test_list_tests_projects_fields(monkeypatch):
+    _mock_get(
+        monkeypatch,
+        {"tests": [{"id": "t1", "status": "PASS", "log_url": "x", "misc": {}}]},
+    )
+    result = tools_dashboard.list_tests(
+        giturl="https://git.example.org/linux.git",
+        branch="master",
+        commit="deadbeef",
+        fields=["id", "status", "nonexistent"],
+    )
+    assert result["tests"] == [{"id": "t1", "status": "PASS"}]
+
+
+SUMMARY_PAYLOAD = {
+    "common": {"tree_name": "mainline"},
+    "summary": {
+        "builds": {
+            "status": {"PASS": 10, "FAIL": 1},
+            "architectures": {"x86_64": {"PASS": 5}},
+            "configs": {"defconfig": {"PASS": 10}},
+            "labs": {"lab-1": {}},
+            "issues": [],
+        },
+        "boots": {
+            "status": {"pass": 20},
+            "failed_platforms": ["board-1"],
+            "environment_misc": {"big": "blob"},
+        },
+    },
+    "filters": {"configs": ["defconfig"]},
+}
+
+
+def test_get_summary_compact_by_default(monkeypatch):
+    _mock_get(monkeypatch, SUMMARY_PAYLOAD)
+    result = tools_dashboard.get_summary(
+        giturl="https://git.example.org/linux.git", branch="master", commit="deadbeef"
+    )
+    assert result["common"] == {"tree_name": "mainline"}
+    assert result["summary"]["builds"] == {
+        "status": {"PASS": 10, "FAIL": 1},
+        "architectures": {"x86_64": {"PASS": 5}},
+        "issues": [],
+    }
+    assert result["summary"]["boots"] == {
+        "status": {"pass": 20},
+        "failed_platforms": ["board-1"],
+    }
+    assert "filters" not in result
+
+
+def test_get_summary_detail_returns_full_payload(monkeypatch):
+    _mock_get(monkeypatch, SUMMARY_PAYLOAD)
+    result = tools_dashboard.get_summary(
+        giturl="https://git.example.org/linux.git",
+        branch="master",
+        commit="deadbeef",
+        detail=True,
+    )
+    assert result == SUMMARY_PAYLOAD


### PR DESCRIPTION
Make get_summary return compact aggregates (status counts, per architecture counts, known issues and failed platforms) with the full payload behind detail=true, drop the default list page size to 20, and add a fields parameter to the list tools, including list_nodes, so callers can project entries to only the keys they need.