### PR TITLE
mcp: mark the MCP server as experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,9 @@ data:
 - retry jobs or trigger custom checkouts (with a token)
 
 Tools that only read data are annotated as read-only, so MCP clients can
-require confirmation before the job-triggering ones run.
+require confirmation before the job-triggering ones run. The MCP server is
+experimental: tool names, parameters and response formats may change
+between releases.
 
 MCP support is an optional extra:
 

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -7,6 +7,10 @@ description = 'Run an MCP server exposing KernelCI data and actions to AI agents
 This command runs an MCP (Model Context Protocol) server so AI agents and
 automation tools can query KernelCI results and drive Maestro jobs.
 
+> **Experimental**: tool names, parameters and response formats may
+> change between releases. Please report any issues on the
+> [issue tracker](https://github.com/kernelci/kci-dev/issues).
+
 MCP support is an optional extra:
 
 ```sh

--- a/kcidev/mcp/__init__.py
+++ b/kcidev/mcp/__init__.py
@@ -7,7 +7,8 @@ from kcidev.api import KernelCIClient
 from kcidev.libs.common import kcidev_version
 from kcidev.mcp import tools_dashboard, tools_maestro
 
-SERVER_INSTRUCTIONS = """KernelCI MCP server.
+SERVER_INSTRUCTIONS = """KernelCI MCP server (experimental: tools,
+parameters and response formats may change between releases).
 
 Query KernelCI build, boot and test results and known issues from the
 web dashboard, inspect Maestro nodes, and, when a token is configured,

--- a/kcidev/subcommands/mcp.py
+++ b/kcidev/subcommands/mcp.py
@@ -11,6 +11,12 @@ from kcidev.libs.common import *
 @click.command(
     help="""Run an MCP (Model Context Protocol) server exposing KernelCI.
 
+EXPERIMENTAL: tool names, parameters and response formats may change
+between releases. Please report any issues at:
+
+\b
+https://github.com/kernelci/kci-dev/issues
+
 Read-only dashboard query tools are always available. Maestro node
 lookup tools are enabled when the configured instance has an 'api' URL,
 and job retry/checkout trigger tools when it also has a 'pipeline' URL


### PR DESCRIPTION
Note in the CLI help, server instructions, docs page and README that tool names, parameters and response formats may change between releases, so users and connecting agents are aware before relying on the interface.