### PR TITLE
testretry: fail clearly when a retry is rejected

### DIFF
--- a/kcidev/subcommands/testretry.py
+++ b/kcidev/subcommands/testretry.py
@@ -49,7 +49,10 @@ def testretry(ctx, nodeid):
         logging.info("Test retry initiated successfully")
         click.secho(resp["message"], fg="green")
     else:
-        logging.warning("No response message from retry request")
+        # send_jobretry already reported the specific API error, if any
+        logging.error(f"Test retry request for node {nodeid} failed")
+        kci_err(f"Test retry request for node {nodeid} failed")
+        raise click.Abort()
 
 
 if __name__ == "__main__":

--- a/tests/test_testretry.py
+++ b/tests/test_testretry.py
@@ -1,0 +1,30 @@
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from kcidev.subcommands.testretry import testretry as retry_command
+
+OBJ = {
+    "CFG": {"staging": {"pipeline": "https://example.test/", "token": "t"}},
+    "INSTANCE": "staging",
+}
+
+
+def _invoke():
+    return CliRunner().invoke(retry_command, ["--nodeid", "n1"], obj=dict(OBJ))
+
+
+def test_testretry_success_prints_message():
+    with patch(
+        "kcidev.subcommands.testretry.send_jobretry", return_value={"message": "OK"}
+    ):
+        result = _invoke()
+    assert result.exit_code == 0
+    assert "OK" in result.output
+
+
+def test_testretry_failure_exits_nonzero():
+    with patch("kcidev.subcommands.testretry.send_jobretry", return_value=None):
+        result = _invoke()
+    assert result.exit_code != 0
+    assert "No response message" not in result.output


### PR DESCRIPTION
On a non-200 the retry helper returns None, but the command logged a misleading 'No response message from retry request' warning and then returned normally, so a rejected retry (e.g. a 401) exited 0 and read as success to scripts and agents. Report the failure and abort with a non-zero exit instead; the helper already surfaces the specific API error.