### PR TITLE
Updated build validation to compare Maestro and dashboard IDs

### DIFF
--- a/kcidev/subcommands/maestro/validate/helper.py
+++ b/kcidev/subcommands/maestro/validate/helper.py
@@ -127,12 +127,11 @@ def get_build_stats(
     )
     if dashboard_builds is None:
         return []
-    missing_build_ids = []
     summary_flag = "✅"
-    if len(dashboard_builds) != len(maestro_builds):
-        missing_build_ids = find_missing_items(
-            maestro_builds, dashboard_builds, "build", verbose
-        )
+    missing_build_ids = find_missing_items(
+        maestro_builds, dashboard_builds, "build", verbose
+    )
+
     builds_with_status_mismatch = validate_build_status(
         maestro_builds, dashboard_builds
     )
@@ -403,12 +402,10 @@ def get_boot_stats(
     )
     if dashboard_boots is None:
         return []
-    missing_boot_ids = []
     summary_flag = "✅"
-    if len(dashboard_boots) != len(maestro_boots):
-        missing_boot_ids = find_missing_items(
-            maestro_boots, dashboard_boots, "boot", verbose
-        )
+    missing_boot_ids = find_missing_items(
+        maestro_boots, dashboard_boots, "boot", verbose
+    )
     boots_with_status_mismatch = validate_boot_status(maestro_boots, dashboard_boots)
     if (
         len(dashboard_boots) != len(maestro_boots)

--- a/tests/test_maestro_validate_stats.py
+++ b/tests/test_maestro_validate_stats.py
@@ -1,0 +1,34 @@
+import pytest
+
+from kcidev.subcommands.maestro.validate import helper
+
+
+@pytest.mark.parametrize(
+    ("get_stats", "get_results", "item_type"),
+    (
+        (helper.get_build_stats, "get_builds", "build"),
+        (helper.get_boot_stats, "get_boots", "boot"),
+    ),
+)
+def test_equal_counts_with_different_ids_fail_validation(
+    monkeypatch, get_stats, get_results, item_type
+):
+    maestro_results = [
+        {
+            "id": "maestro-only",
+            "result": "pass",
+            "retry_counter": 0,
+            "data": {},
+        }
+    ]
+    dashboard_results = [{"id": f"{item_type}:dashboard-only", "status": "PASS"}]
+    monkeypatch.setattr(
+        helper,
+        get_results,
+        lambda *args, **kwargs: (maestro_results, dashboard_results),
+    )
+
+    stats = get_stats(None, "url", "branch", "commit", "tree", False, None)
+
+    assert stats[2:5] == [1, 1, "❌"]
+    assert stats[5] == ["dashboard-only"]


### PR DESCRIPTION
This prevents equal result counts with different IDs from reporting a false success