### PR TITLE
Fix maestro results output

### DIFF
--- a/kcidev/libs/maestro_common.py
+++ b/kcidev/libs/maestro_common.py
@@ -60,7 +60,7 @@ def maestro_print_nodes(nodes, field):
             res.append(data)
         else:
             res.append(node)
-        kci_msg(json.dumps(res, sort_keys=True, indent=4))
+    kci_msg(json.dumps(res, sort_keys=True, indent=4))
 
 
 def maestro_get_node(url, nodeid):

--- a/kcidev/subcommands/maestro/results.py
+++ b/kcidev/subcommands/maestro/results.py
@@ -155,7 +155,7 @@ def results(
 
     logging.debug(f"Displaying results with fields: {field if field else 'all'}")
 
-    if verbose:
+    if verbose and not (nodes and count):
         maestro_print_nodes(results, field)
     return results
 

--- a/tests/test_maestro_common.py
+++ b/tests/test_maestro_common.py
@@ -42,6 +42,17 @@ def test_maestro_get_node_missing_raises_clean_error(monkeypatch):
         maestro_common.maestro_get_node("https://api.example.org/", "0" * 24)
 
 
+def test_maestro_print_nodes_emits_one_json_document(capsys):
+    nodes = [{"id": "node-1", "name": "first"}, {"id": "node-2", "name": "second"}]
+
+    maestro_common.maestro_print_nodes(nodes, ("id",))
+
+    assert json.loads(capsys.readouterr().out) == [
+        {"id": "node-1"},
+        {"id": "node-2"},
+    ]
+
+
 def _response(status_code=200, json_data=None):
     response = Mock(status_code=status_code)
     response.json.return_value = json_data

--- a/tests/test_maestro_results.py
+++ b/tests/test_maestro_results.py
@@ -1,0 +1,29 @@
+import importlib
+from unittest.mock import Mock
+
+from click.testing import CliRunner
+
+from kcidev.subcommands.maestro import results as results_command
+
+results_module = importlib.import_module("kcidev.subcommands.maestro.results")
+
+
+def test_count_does_not_print_nodes(monkeypatch):
+    nodes = [{"id": "node-1"}, {"id": "node-2"}]
+    get_nodes = Mock(return_value=nodes)
+    print_nodes = Mock()
+    monkeypatch.setattr(results_module, "maestro_get_nodes", get_nodes)
+    monkeypatch.setattr(results_module, "maestro_print_nodes", print_nodes)
+
+    result = CliRunner().invoke(
+        results_command,
+        ["--nodes", "--count"],
+        obj={
+            "CFG": {"production": {"api": "https://api.example.org/"}},
+            "INSTANCE": "production",
+        },
+    )
+
+    assert result.exit_code == 0
+    assert result.output == "2\n"
+    print_nodes.assert_not_called()


### PR DESCRIPTION
The help says --count will “Print only count of nodes,” but after printing the count, the command also prints every result because verbose defaults to true.

Additionally, maestro_print_nodes() prints the growing result list inside the loop. With two nodes, it emits one JSON array containing node 1 and then another array containing nodes 1 and 2. That output is not one valid JSON document and repeats data.