### PR TITLE
bisect: match git's quoted bad-commit completion output

### DIFF
--- a/kcidev/subcommands/bisect.py
+++ b/kcidev/subcommands/bisect.py
@@ -106,7 +106,7 @@ def git_exec_getcommit(cmd):
         kci_err(f"git command answer length failed: {lines}")
         sys.exit(1)
     # is it last bisect?: "is the first bad commit"
-    if "is the first bad commit" in output:
+    if re.search(r"is the first '?bad'? commit", output):
         first_bad = output.split()[0]
         logging.info("Bisection complete - found first bad commit")
         click.secho(f"First bad commit: {first_bad}", fg="green")


### PR DESCRIPTION
Newer git prints "<sha> is the first 'bad' commit" with the term quoted, so the plain substring check missed the completion case and the next-commit regex then failed, exiting with an error. Match the term with or without quotes.